### PR TITLE
Test Results created from a cancellation don't save test_id.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -125,7 +125,13 @@ namespace BASE_PATH do
 
     sequence.tests.each_with_index do |test, index|
       next if index < current_test_count
-      @sequence_result.test_results << TestResult.new(name: test[:name], result: 'cancel', url: test[:url], description: test[:description], test_index: test[:test_index], message: cancel_message)
+      @sequence_result.test_results << TestResult.new(test_id: test[:test_id],
+                                                      name: test[:name],
+                                                      result: 'cancel',
+                                                      url: test[:url],
+                                                      description: test[:description],
+                                                      test_index: test[:test_index],
+                                                      message: cancel_message)
     end
 
     @sequence_result.save!


### PR DESCRIPTION
We allow users to cancel sequences in progress.  In practice this is currently only used in the EHR launch sequence, which is why we missed it the first time around.

To recreate the error, try starting an EHR launch, but then click 'cancel'.  That will cause a test result without a test_id to be saved, which causes the webpage to break.

This just makes sure that test_id gets passed to the test result properly.