### PR TITLE
Prevent streaming from timing out.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -64,6 +64,25 @@ helpers do
   def show_tutorial
     settings.show_tutorial
   end
+
+  def js_hide_wait_modal
+    "<script>console.log('hide_wait_modal');$('#WaitModal').modal('hide');</script>"
+  end
+  def js_show_test_modal
+    "<script>console.log('show_test_modal');$('#testsRunningModal').modal('show')</script>"
+  end
+  def js_stayalive(time)
+    "<script>console.log('Time running: ' + #{time})</script>"
+  end
+  def js_update_result(result, count, total)
+    "<script>console.log('js_update_result');$('#testsRunningModal').find('.number-complete').html('(#{count} of #{total} complete)');</script>"
+  end
+  def js_redirect(location)
+    "<script>console.log('js_window_location'); window.location = '#{location}'</script>"
+  end
+  def js_redirect_modal(location)
+    "<script>console.log('js_redirect_modal');$('#testsRunningModal').find('.modal-body').html('Redirecting to <textarea readonly class=\"form-control\" rows=\"3\">#{location}</textarea>');</script>"
+  end
 end
 
 get '/' do
@@ -141,23 +160,39 @@ namespace BASE_PATH do
     client.use_dstu2
     client.default_json
     klass = SequenceBase.subclasses.find{|x| x.to_s.start_with?(params[:sequence])}
+
+    timer_count = 0;
+    stayalive_timer_seconds = 20;
+
     if klass
       sequence = klass.new(instance, client, settings.disable_tls_tests)
-      stream do |out|
-        out << erb(:details, {}, {instance: instance, sequences: SequenceBase.ordered_sequences, sequence_results: instance.latest_results, tests_running: true})
-        out << "<script>$('#WaitModal').modal('hide')</script>"
-        out << "<script>$('#testsRunningModal').modal('show')</script>"
+      stream :keep_open do |out|
+
+        EventMachine::PeriodicTimer.new(stayalive_timer_seconds) do
+          timer_count = timer_count + 1;
+          out << js_stayalive(timer_count * stayalive_timer_seconds)
+        end
+
+        out << erb(:details, {}, {instance: instance,
+                                  sequences: SequenceBase.ordered_sequences,
+                                  sequence_results: instance.latest_results,
+                                  tests_running: true
+                                 }
+                  )
+        out << js_show_test_modal
         count = 0
         sequence_result = sequence.start do |result|
           count = count + 1
-          out << "<script>$('#testsRunningModal').find('.number-complete').html('(#{count} of #{sequence.test_count} complete)');</script>"
+
+          out << js_update_result(result, count, sequence.test_count)
         end
+
         sequence_result.save!
         if sequence_result.redirect_to_url
-          out << "<script>$('#testsRunningModal').find('.modal-body').html('Redirecting to <textarea readonly class=\"form-control\" rows=\"3\">#{sequence_result.redirect_to_url}</textarea>');</script>"
-          out << "<script> window.location = '#{sequence_result.redirect_to_url}'</script>"
+          out << js_redirect_modal(sequence_result.redirect_to_url)
+          out << js_redirect(sequence_result.redirect_to_url)
         else
-          out << "<script> window.location = '#{BASE_PATH}/#{params[:id]}/##{params[:sequence]}'</script>"
+          out << js_redirect("#{BASE_PATH}/#{params[:id]}/##{params[:sequence]}")
         end
       end
 
@@ -283,23 +318,38 @@ namespace BASE_PATH do
       client.use_dstu2
       client.default_json
       sequence = klass.new(instance, client, settings.disable_tls_tests, sequence_result)
+
+      timer_count = 0;
+      stayalive_timer_seconds = 20;
+
       stream do |out|
-        out << erb(:details, {}, {instance: instance, sequences: SequenceBase.ordered_sequences, sequence_results: instance.latest_results, tests_running: true})
-        out << "<script>$('#WaitModal').modal('hide')</script>"
-        out << "<script>$('#testsRunningModal').modal('show')</script>"
+
+        EventMachine::PeriodicTimer.new(stayalive_timer_seconds) do
+          timer_count = timer_count + 1;
+          out << js_stayalive(timer_count * stayalive_timer_seconds)
+        end
+
+        out << erb(:details, {}, {instance: instance,
+                                  sequences: SequenceBase.ordered_sequences,
+                                  sequence_results: instance.latest_results,
+                                  tests_running: true}
+                  )
+
+        out << js_hide_wait_modal
+        out << js_show_test_modal
         count = sequence_result.test_results.length
         sequence_result = sequence.resume(request, headers, request.params) do |result|
           count = count + 1
-          out << "<script>$('#testsRunningModal').find('.number-complete').html('(#{count} of #{sequence.test_count} complete)');</script>"
+          out << js_update_result(result, count, sequence_results.total)
           instance.save!
         end
         instance.sequence_results.push(sequence_result)
         instance.save!
         if sequence_result.redirect_to_url
-          out << "<script>$('#testsRunningModal').find('.modal-body').html('Redirecting to <textarea readonly class=\"form-control\" rows=\"3\">#{sequence_result.redirect_to_url}</textarea>');</script>"
-          out << "<script> window.location = '#{sequence_result.redirect_to_url}'</script>"
+          out << js_redirect_modal(sequence_result.redirect_to_url)
+          out << js_redirect(sequence_result.redirect_to_url)
         else
-          out << "<script> window.location = '#{BASE_PATH}/#{params[:id]}/##{params[:sequence]}'</script>"
+          out << js_redirect('#{BASE_PATH}/#{params[:id]}/##{params[:sequence]}')
         end
       end
     end


### PR DESCRIPTION
EventMachine has the ability to periodically send data out over an open connection.  By sending out data every 20 seconds, browsers won't close the connection preemptively.

To test, you can try the SSL problem we have internally, and note that every 20 seconds content will print out to the javascript console.  The browser's 'loading' spinner (in chrome it is in the tab) should continue to spin.  After about 3 minutes the page will refresh (because the SSL socket connection finally timed out).

Before, the browser would timeout after 30 seconds.  In chrome, the 'loading' spinner will stop and the page would be 'dead', with the test run modal never doing anything.

There is more we can do here, but I think this addresses the core problem and I'd like to get it merged in quickly to make sure we shake out any problems before the next deployment.

I also pulled out JS rendering into their own functions to aid in readability.