### PR TITLE
Add browser support warning, README information, and save state warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Implementation Guides, and [FHIR DSTU2](http://hl7.org/fhir/DSTU2/index.html).
 * [Ruby Bundler](http://bundler.io/)
 * [SQLite](https://www.sqlite.org/)
 
+## Supported Browsers
+
+Inferno has been tested on the latest versions of Chrome, Firefox, Safari, and Edge.  Internet Explorer is not supported at this time.
+
 ## Installation and Running
 
 ### Local Installation

--- a/views/details.erb
+++ b/views/details.erb
@@ -379,8 +379,11 @@
         <p>
           The results recorded during this testing session can be accessed at the following URI.
           Please save this URI if you would like to revisit these results, as this secret URI will not be published.
-          </p>
+        </p>
           <input type="text" class="form-control" value="<%=instance.base_url%><%=BASE_PATH%>/<%=instance.id%>/" readonly="readonly">
+        <p class='alert alert-warning'>
+          This URI is not guaranteed to be permanently accessible.  The team maintaining this instance of Inferno may choose to periodically clear the database.  To ensure that test results are saved indefinitely, it is recommended that users download, install, and use Inferno on their own hardware.
+        </p>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
         </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -28,6 +28,11 @@
         </ul>
       </div>
     </nav>
+    <script type="text/javascript">
+      if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent))
+        alert('Inferno does not currently support Internet Explorer.  Please switch to another browser, such as Chrome, Firefox, Safari, or Edge.');
+    </script>
+
     <%= yield %>
     <footer class="footer">
       <div class="container row">


### PR DESCRIPTION
This resolves some minor issues:
* Adds an alert targeted solely at Internet Explorer warning about Inferno support
* Adds language to the README about supported browsers
* Adds an alert to the Save button about how tests may not be stored perpetually