### PR TITLE
Fix issue when server states OAuth endpoints but is not explicit about smart support.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.25)
-    fhir_client (3.0.5)
+    fhir_client (3.0.6)
       activesupport (>= 3)
       addressable (>= 2.3)
       fhir_dstu2_models (>= 1.0.4)

--- a/lib/app/sequences/01_conformance_sequence.rb
+++ b/lib/app/sequences/01_conformance_sequence.rb
@@ -164,7 +164,7 @@ module Inferno
         }
 
         assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
-        oauth_metadata = @client.get_oauth2_metadata_from_conformance
+        oauth_metadata = @client.get_oauth2_metadata_from_conformance(false) # strict mode off, don't require server to state smart conformance
         assert !oauth_metadata.nil?, 'No OAuth Metadata in conformance statement'
         authorize_url = oauth_metadata[:authorize_url]
         token_url = oauth_metadata[:token_url]

--- a/lib/app/sequences/01_conformance_sequence.rb
+++ b/lib/app/sequences/01_conformance_sequence.rb
@@ -173,6 +173,12 @@ module Inferno
         assert !token_url.blank?, 'No token URI provided in conformance statement.'
         assert (token_url =~ /\A#{URI::regexp(['http', 'https'])}\z/) == 0, "Invalid token url: '#{token_url}'"
 
+        warning {
+          service = @conformance.try(:rest).try(:first).try(:security).try(:service).try(:coding).try(:code)
+          assert !service.nil?, 'No security services listed. Conformance.rest.security.service should be SMART-on-FHIR.'
+          assert service == 'SMART-on-FHIR', "Conformance.rest.security.service set to #{service}.  It should be SMART-on-FHIR."
+        }
+
         registration_url = nil
 
         warning {
@@ -217,6 +223,7 @@ module Inferno
         ]
 
         assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
+
         extensions = @conformance.try(:rest).try(:first).try(:security).try(:extension)
         assert !extensions.nil?, 'No SMART capabilities listed in conformance.'
         capabilities = extensions.select{|x| x.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities' }

--- a/lib/app/sequences/03_patient_standalone_launch_sequence.rb
+++ b/lib/app/sequences/03_patient_standalone_launch_sequence.rb
@@ -191,7 +191,7 @@ module Inferno
         @instance.update(token: @token_response_body['access_token'], token_retrieved_at: token_retrieved_at)
 
         [:cache_control, :pragma].each do |key|
-          assert @token_response_headers.has_key?(key), "Token response headers did not contain #{key} as required"
+          assert @token_response_headers.has_key?(key), "Token response headers did not contain #{key} as is required in the SMART App Authorization Guide."
         end
 
         assert @token_response_headers[:cache_control].downcase.include?('no-store'), 'Token response header must have cache_control containing no-store.'


### PR DESCRIPTION
This is a very frequent issue -- the server provides OAuth endpoints but isn't explicit about SMART support.  We updated the client so that we can be relaxed about this issue (note the 3.0.6 client bump).

Perhaps we should add a warning about this?  Notably, the SMART r2 reference server has this issue.