### PR TITLE
Add missing params for OIDC and Token Refresh sequences.

### DIFF
--- a/lib/app/views/details.erb
+++ b/lib/app/views/details.erb
@@ -183,6 +183,16 @@
                                           value: instance.patient_id,
                                           })%>
 
+          <%= erb(:prerequisite_field,{},{prerequisite: :id_token,
+                                          label: 'OAuth 2.0 ID Token',
+                                          value: instance.id_token,
+                                          })%>
+
+          <%= erb(:prerequisite_field,{},{prerequisite: :refresh_token,
+                                          label: 'Refresh Token',
+                                          value: instance.refresh_token,
+                                          })%>
+
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>


### PR DESCRIPTION
OIDC and Token Refresh weren't showing all the required params in the popup before the run. OIDC should show the id_token and Token Refresh should show the refresh token.