### PR TITLE
Break out launch header checks into separate tests to be more dev friendly.

### DIFF
--- a/lib/app/sequences/03_patient_standalone_launch_sequence.rb
+++ b/lib/app/sequences/03_patient_standalone_launch_sequence.rb
@@ -170,7 +170,6 @@ module Inferno
           id '07'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
           desc %(
-            The authorization servers response must include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.
             The EHR authorization server shall return a JSON structure that includes an access token or a message indicating that the authorization request has been denied.
             access_token, token_type, and scope are required. access_token must be Bearer.
           )
@@ -189,13 +188,6 @@ module Inferno
         @instance.save!
 
         @instance.update(token: @token_response_body['access_token'], token_retrieved_at: token_retrieved_at)
-
-        [:cache_control, :pragma].each do |key|
-          assert @token_response_headers.has_key?(key), "Token response headers did not contain #{key} as is required in the SMART App Authorization Guide."
-        end
-
-        assert @token_response_headers[:cache_control].downcase.include?('no-store'), 'Token response header must have cache_control containing no-store.'
-        assert @token_response_headers[:pragma].downcase.include?('no-cache'), 'Token response header must have pragma containing no-cache.'
 
         ['token_type', 'scope'].each do |key|
           assert @token_response_body.has_key?(key), "Token response did not contain #{key} as required"
@@ -229,6 +221,25 @@ module Inferno
           @instance.update(refresh_token: @token_response_body['refresh_token'])
         end
 
+
+      end
+
+      test 'Response includes correct HTTP Cache-Control and Pragma headers' do
+
+        metadata {
+          id '08'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          desc %(
+            The authorization servers response must include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.
+          )
+        }
+
+        [:cache_control, :pragma].each do |key|
+          assert @token_response_headers.has_key?(key), "Token response headers did not contain #{key} as is required in the SMART App Launch Guide."
+        end
+
+        assert @token_response_headers[:cache_control].downcase.include?('no-store'), 'Token response header must have cache_control containing no-store.'
+        assert @token_response_headers[:pragma].downcase.include?('no-cache'), 'Token response header must have pragma containing no-cache.'
       end
 
     end

--- a/lib/app/sequences/07_token_refresh_sequence.rb
+++ b/lib/app/sequences/07_token_refresh_sequence.rb
@@ -64,7 +64,6 @@ module Inferno
           id '03'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
           desc %(
-           The authorization servers response MUST include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.
            The EHR authorization server SHALL return a JSON structure that includes an access token or a message indicating that the authorization request has been denied.
            access_token, token_type, and scope are required. access_token must be Bearer.
           )
@@ -83,13 +82,6 @@ module Inferno
         @instance.save!
 
         @instance.update(token: @token_response_body['access_token'], token_retrieved_at: token_retrieved_at)
-
-        [:cache_control, :pragma].each do |key|
-          assert @token_response_headers.has_key?(key), "Token response headers did not contain #{key} as required"
-        end
-
-        assert @token_response_headers[:cache_control].downcase.include?('no-store'), 'Token response header must have cache_control containing no-store.'
-        assert @token_response_headers[:pragma].downcase.include?('no-cache'), 'Token response header must have pragma containing no-cache.'
 
         ['token_type', 'scope'].each do |key|
           assert @token_response_body.has_key?(key), "Token response did not contain #{key} as required"
@@ -123,6 +115,24 @@ module Inferno
           @instance.update(refresh_token: @token_response_body['refresh_token'])
         end
 
+      end
+
+      test 'Response includes correct HTTP Cache-Control and Pragma headers' do
+
+        metadata {
+          id '10'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          desc %(
+            The authorization servers response must include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.
+          )
+        }
+
+        [:cache_control, :pragma].each do |key|
+          assert @token_response_headers.has_key?(key), "Token response headers did not contain #{key} as is required in the SMART App Launch Guide."
+        end
+
+        assert @token_response_headers[:cache_control].downcase.include?('no-store'), 'Token response header must have cache_control containing no-store.'
+        assert @token_response_headers[:pragma].downcase.include?('no-cache'), 'Token response header must have pragma containing no-cache.'
       end
 
     end


### PR DESCRIPTION
If a server correctly passes back information like the id_token and the refresh_token, they should be saved, even if something else goes wrong within the same test (like a header is missing).  This is largely a test granularity problem, and in this case too many things were logically put into a single test (and something early fails, preventing other working things from running).  I think it could be broken out even more, but this is a start.

To replicate, use the following FHIR server:

```
https://launch.smarthealthit.org/v/r2/sim/eyJrIjoiMSIsImoiOiIxIiwiYiI6InNtYXJ0LTEwOTg2NjcifQ/fhir
```

Any `client_id` can be used, and password on the login prompt can be used.

When you run the standalone launch sequence, the id_token isn't saved because an earlier assertion (regarding headers) fails.  It should save the id_token because it is returned.  I split out header checks into a separate test.

This applies to the Standalone Launch, the EHR Launch and the Token Refresh Sequences.