### PR TITLE
Conformance Supports Check

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,7 +18,7 @@ disable_verify_peer: false
 bind: '0.0.0.0'
 
 # Skip TLS tests
-disable_tls_tests: false
+disable_tls_tests: true
 
 # Default scopes
 default_scopes: launch launch/patient offline_access openid profile user/*.* patient/*.*

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -31,6 +31,7 @@ module Inferno
       @@descriptions = {}
       @@details = {}
       @@requires = {}
+      @@conformance_supports = {}
       @@defines = {}
       @@test_metadata = {}
 
@@ -224,6 +225,11 @@ module Inferno
       def self.requires(*requires)
         @@requires[self.sequence_name] = requires unless requires.empty?
         @@requires[self.sequence_name] || []
+      end
+
+      def self.conformance_supports(*supports)
+        @@conformance_supports[self.sequence_name] = supports unless supports.empty?
+        @@conformance_supports[self.sequence_name] || []
       end
 
       def self.missing_requirements(instance, recurse = false)

--- a/lib/app/sequences/02_dynamic_registration_sequence.rb
+++ b/lib/app/sequences/02_dynamic_registration_sequence.rb
@@ -18,7 +18,7 @@ module Inferno
         This sequence tests tests this functionality by dynamically an app for Inferno to use in later sequences.
 
       )
-
+      
       test_id_prefix 'DR'
 
       optional

--- a/lib/app/sequences/08a_argonaut_patient_sequence.rb
+++ b/lib/app/sequences/08a_argonaut_patient_sequence.rb
@@ -226,7 +226,7 @@ module Inferno
             All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support.          )
         }
 
-        skip_if_not_supported(:Patient, [:history])
+         
 
         validate_history_reply(@patient, FHIR::DSTU2::Patient)
 
@@ -243,7 +243,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Patient, [:vread])
+         
 
         validate_vread_reply(@patient, FHIR::DSTU2::Patient)
 

--- a/lib/app/sequences/08a_argonaut_patient_sequence.rb
+++ b/lib/app/sequences/08a_argonaut_patient_sequence.rb
@@ -9,6 +9,7 @@ module Inferno
       test_id_prefix 'ARPA'
 
       requires :token, :patient_id
+      conformance_supports :Patient
 
       test 'Server rejects patient read without proper authorization' do
 

--- a/lib/app/sequences/08b_argonaut_allergy_intolerance_sequence.rb
+++ b/lib/app/sequences/08b_argonaut_allergy_intolerance_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARAI'
 
       requires :token, :patient_id
+      conformance_supports :AllergyIntolerance
 
       test 'Server rejects AllergyIntolerance search without authorization' do
 

--- a/lib/app/sequences/08b_argonaut_allergy_intolerance_sequence.rb
+++ b/lib/app/sequences/08b_argonaut_allergy_intolerance_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:AllergyIntolerance, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -44,7 +44,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:AllergyIntolerance, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::AllergyIntolerance, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -73,7 +73,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:AllergyIntolerance, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@allergyintolerance, FHIR::DSTU2::AllergyIntolerance)
@@ -91,7 +91,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:AllergyIntolerance, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
         validate_history_reply(@allergyintolerance, FHIR::DSTU2::AllergyIntolerance)
 
@@ -108,7 +108,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:AllergyIntolerance, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@allergyintolerance, FHIR::DSTU2::AllergyIntolerance)

--- a/lib/app/sequences/08c_argonaut_careplan_sequence.rb
+++ b/lib/app/sequences/08c_argonaut_careplan_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
@@ -43,7 +43,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan"})
         assert_bundle_response(reply)
@@ -73,7 +73,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@careplan.nil?, 'Expected valid DSTU2 CarePlan resource to be present'
@@ -96,7 +96,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", status: "active"})
@@ -115,7 +115,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@careplan.nil?, 'Expected valid DSTU2 CarePlan resource to be present'
@@ -136,7 +136,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@careplan, FHIR::DSTU2::CarePlan)
@@ -154,7 +154,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@careplan, FHIR::DSTU2::CarePlan)
@@ -172,7 +172,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@careplan, FHIR::DSTU2::CarePlan)

--- a/lib/app/sequences/08c_argonaut_careplan_sequence.rb
+++ b/lib/app/sequences/08c_argonaut_careplan_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARCP'
 
       requires :token, :patient_id
+      conformance_supports :CarePlan
 
       test 'Server rejects CarePlan search without authorization' do
 

--- a/lib/app/sequences/08d_argonaut_careteam_sequence.rb
+++ b/lib/app/sequences/08d_argonaut_careteam_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARCT'
 
       requires :token, :patient_id
+      conformance_supports :CarePlan
 
       test 'Server returns expected CareTeam results from CarePlan search by patient + category' do
 

--- a/lib/app/sequences/08d_argonaut_careteam_sequence.rb
+++ b/lib/app/sequences/08d_argonaut_careteam_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "careteam"})
         @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)

--- a/lib/app/sequences/08e_argonaut_condition_sequence.rb
+++ b/lib/app/sequences/08e_argonaut_condition_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -44,7 +44,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -74,7 +74,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, clinicalstatus: "active,recurrance,remission"})
@@ -93,7 +93,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, category: "problem"})
@@ -112,7 +112,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, category: "health-concern"})
@@ -130,7 +130,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@condition, FHIR::DSTU2::Condition)
@@ -148,7 +148,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@condition, FHIR::DSTU2::Condition)
@@ -166,7 +166,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Condition, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@condition, FHIR::DSTU2::Condition)

--- a/lib/app/sequences/08e_argonaut_condition_sequence.rb
+++ b/lib/app/sequences/08e_argonaut_condition_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARCO'
 
       requires :token, :patient_id
+      conformance_supports :Condition
 
       test 'Server rejects Condition search without authorization' do
 

--- a/lib/app/sequences/08f_argonaut_device_sequence.rb
+++ b/lib/app/sequences/08f_argonaut_device_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARDE'
 
       requires :token, :patient_id
+      conformance_supports :Device
 
       test 'Server rejects Device search without authorization' do
 

--- a/lib/app/sequences/08f_argonaut_device_sequence.rb
+++ b/lib/app/sequences/08f_argonaut_device_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Device, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -44,7 +44,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Device, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Device, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -73,7 +73,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Device, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@device, FHIR::DSTU2::Device)
@@ -91,7 +91,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Device, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@device, FHIR::DSTU2::Device)
@@ -109,7 +109,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Device, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@device, FHIR::DSTU2::Device)

--- a/lib/app/sequences/08g_argonaut_diagnostic_report_sequence.rb
+++ b/lib/app/sequences/08g_argonaut_diagnostic_report_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -44,7 +44,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB"})
         assert_bundle_response(reply)
@@ -72,7 +72,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@diagnosticreport.nil?, 'Expected valid DSTU2 DiagnosticReport resource to be present'
@@ -93,7 +93,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@diagnosticreport.nil?, 'Expected valid DSTU2 DiagnosticReport resource to be present'
@@ -115,7 +115,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@diagnosticreport.nil?, 'Expected valid DSTU2 DiagnosticReport resource to be present'
@@ -138,7 +138,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@diagnosticreport, FHIR::DSTU2::DiagnosticReport)
@@ -156,7 +156,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@diagnosticreport, FHIR::DSTU2::DiagnosticReport)
@@ -174,7 +174,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:DiagnosticReport, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@diagnosticreport, FHIR::DSTU2::DiagnosticReport)

--- a/lib/app/sequences/08g_argonaut_diagnostic_report_sequence.rb
+++ b/lib/app/sequences/08g_argonaut_diagnostic_report_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARDR'
 
       requires :token, :patient_id
+      conformance_supports :DiagnosticReport
 
       test 'Server rejects DiagnosticReport search without authorization' do
 

--- a/lib/app/sequences/08h_argonaut_observation_sequence.rb
+++ b/lib/app/sequences/08h_argonaut_observation_sequence.rb
@@ -21,7 +21,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -42,7 +42,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory"})
         assert_bundle_response(reply)
@@ -71,7 +71,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@observationresults.nil?, 'Expected valid DSTU2 Observation resource to be present'
@@ -92,7 +92,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@observationresults.nil?, 'Expected valid DSTU2 Observation resource to be present'
@@ -114,7 +114,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@observationresults.nil?, 'Expected valid DSTU2 Observation resource to be present'
@@ -137,7 +137,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         @client.set_no_auth
@@ -159,7 +159,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, code: "72166-2"})
@@ -179,7 +179,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@observationresults, FHIR::DSTU2::Observation)
@@ -197,7 +197,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@observationresults, FHIR::DSTU2::Observation)
@@ -215,7 +215,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@observationresults, FHIR::DSTU2::Observation)

--- a/lib/app/sequences/08h_argonaut_observation_sequence.rb
+++ b/lib/app/sequences/08h_argonaut_observation_sequence.rb
@@ -9,6 +9,7 @@ module Inferno
       test_id_prefix 'AROB'
 
       requires :token, :patient_id
+      conformance_supports :Observation
 
       test 'Observation Results search without authorization' do
 

--- a/lib/app/sequences/08i_argonaut_goal_sequence.rb
+++ b/lib/app/sequences/08i_argonaut_goal_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ADQ'
 
       requires :token, :patient_id
+      conformance_supports :Goal
 
       test 'Server rejects Goal search without authorization' do
 

--- a/lib/app/sequences/08i_argonaut_goal_sequence.rb
+++ b/lib/app/sequences/08i_argonaut_goal_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Goal, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -44,7 +44,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Goal, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -73,7 +73,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Goal, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@goal.nil?, 'Expected valid DSTU2 Goal resource to be present'
@@ -94,7 +94,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Goal, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@goal, FHIR::DSTU2::Goal)
@@ -112,7 +112,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Goal, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@goal, FHIR::DSTU2::Goal)
@@ -130,7 +130,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Goal, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@goal, FHIR::DSTU2::Goal)

--- a/lib/app/sequences/08j_argonaut_immunization_sequence.rb
+++ b/lib/app/sequences/08j_argonaut_immunization_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARIM'
 
       requires :token, :patient_id
+      conformance_supports :Immunization
 
       test 'Server rejects Immunization search without authorization' do
 

--- a/lib/app/sequences/08j_argonaut_immunization_sequence.rb
+++ b/lib/app/sequences/08j_argonaut_immunization_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Immunization, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -43,7 +43,7 @@ module Inferno
             A client has connected to a server and fetched all immunizations for a patient.          )
         }
 
-        skip_if_not_supported(:Immunization, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Immunization, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -72,7 +72,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Immunization, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@immunization, FHIR::DSTU2::Immunization)
@@ -90,7 +90,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Immunization, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@immunization, FHIR::DSTU2::Immunization)
@@ -108,7 +108,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Immunization, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@immunization, FHIR::DSTU2::Immunization)

--- a/lib/app/sequences/08k_argonaut_medication_sequence.rb
+++ b/lib/app/sequences/08k_argonaut_medication_sequence.rb
@@ -25,7 +25,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -46,7 +46,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::MedicationStatement, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -75,7 +75,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@medicationstatement, FHIR::DSTU2::MedicationStatement)
@@ -93,7 +93,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@medicationstatement, FHIR::DSTU2::MedicationStatement)
@@ -111,7 +111,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@medicationstatement, FHIR::DSTU2::MedicationStatement)

--- a/lib/app/sequences/08k_argonaut_medication_sequence.rb
+++ b/lib/app/sequences/08k_argonaut_medication_sequence.rb
@@ -13,6 +13,7 @@ module Inferno
       inactive
 
       requires :token, :patient_id
+      conformance_supports :MedicationStatement
 
       test 'Server rejects MedicationStatement search without authorization' do
 
@@ -124,7 +125,7 @@ module Inferno
           link 'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medication.html'
           optional
           desc %(
-            MedicationSatement resources associated with Patient conform to Argonaut profiles.
+            MedicationStatement resources associated with Patient conform to Argonaut profiles.
           )
         }
         test_resources_against_profile('MedicationStatement')

--- a/lib/app/sequences/08l_argonaut_medication_order_sequence.rb
+++ b/lib/app/sequences/08l_argonaut_medication_order_sequence.rb
@@ -10,6 +10,8 @@ module Inferno
 
       requires :token, :patient_id
 
+      conformance_supports :MedicationOrder
+
       test 'Server rejects MedicationOrder search without authorization' do
 
         metadata {

--- a/lib/app/sequences/08l_argonaut_medication_order_sequence.rb
+++ b/lib/app/sequences/08l_argonaut_medication_order_sequence.rb
@@ -22,7 +22,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationOrder, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -43,7 +43,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationOrder, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -72,7 +72,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationOrder, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@medicationorder, FHIR::DSTU2::MedicationOrder)
@@ -90,7 +90,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationOrder, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@medicationorder, FHIR::DSTU2::MedicationOrder)
@@ -108,7 +108,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationOrder, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@medicationorder, FHIR::DSTU2::MedicationOrder)

--- a/lib/app/sequences/08m_argonaut_medication_statement_sequence.rb
+++ b/lib/app/sequences/08m_argonaut_medication_statement_sequence.rb
@@ -9,6 +9,7 @@ module Inferno
       test_id_prefix 'ARMS'
 
       requires :token, :patient_id
+      conformance_supports :MedicationStatement
 
       test 'Server rejects MedicationStatement search without authorization' do
 

--- a/lib/app/sequences/08m_argonaut_medication_statement_sequence.rb
+++ b/lib/app/sequences/08m_argonaut_medication_statement_sequence.rb
@@ -21,7 +21,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -42,7 +42,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::MedicationStatement, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -71,7 +71,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@medicationstatement, FHIR::DSTU2::MedicationStatement)
@@ -89,7 +89,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@medicationstatement, FHIR::DSTU2::MedicationStatement)
@@ -107,7 +107,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:MedicationStatement, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@medicationstatement, FHIR::DSTU2::MedicationStatement)

--- a/lib/app/sequences/08n_argonaut_procedure_sequence.rb
+++ b/lib/app/sequences/08n_argonaut_procedure_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Procedure, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -45,7 +45,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Procedure, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id})
         assert_bundle_response(reply)
@@ -73,7 +73,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Procedure, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@procedure.nil?, 'Expected valid DSTU2 Procedure resource to be present'
@@ -94,7 +94,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Procedure, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@procedure, FHIR::DSTU2::Procedure)
@@ -112,7 +112,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Procedure, [:history])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@procedure, FHIR::DSTU2::Procedure)
@@ -130,7 +130,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Procedure, [:vread])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@procedure, FHIR::DSTU2::Procedure)

--- a/lib/app/sequences/08n_argonaut_procedure_sequence.rb
+++ b/lib/app/sequences/08n_argonaut_procedure_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARPR'
 
       requires :token, :patient_id
+      conformance_supports :Procedure
 
       test 'Server rejects Procedure search without authorization' do
 

--- a/lib/app/sequences/08o_smoking_status_sequence.rb
+++ b/lib/app/sequences/08o_smoking_status_sequence.rb
@@ -23,7 +23,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -44,7 +44,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, code: "72166-2"})
         validate_search_reply(FHIR::DSTU2::Observation, reply)

--- a/lib/app/sequences/08o_smoking_status_sequence.rb
+++ b/lib/app/sequences/08o_smoking_status_sequence.rb
@@ -11,6 +11,7 @@ module Inferno
       test_id_prefix 'ARSS'
 
       requires :token, :patient_id
+      conformance_supports :Observation
 
       test 'Server rejects Smoking Status search without authorization' do
 

--- a/lib/app/sequences/08p_vital_signs_observation_sequence.rb
+++ b/lib/app/sequences/08p_vital_signs_observation_sequence.rb
@@ -21,7 +21,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
@@ -42,7 +42,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
 
         reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs"})
         assert_bundle_response(reply)
@@ -72,7 +72,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@vitalsigns.nil?, 'Expected valid DSTU2 Observation resource to be present'
@@ -93,7 +93,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@vitalsigns.nil?, 'Expected valid DSTU2 Observation resource to be present'
@@ -114,7 +114,7 @@ module Inferno
           )
         }
 
-        skip_if_not_supported(:Observation, [:search, :read])
+         
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         assert !@vitalsigns.nil?, 'Expected valid DSTU2 Observation resource to be present'

--- a/lib/app/sequences/08p_vital_signs_observation_sequence.rb
+++ b/lib/app/sequences/08p_vital_signs_observation_sequence.rb
@@ -9,6 +9,7 @@ module Inferno
       test_id_prefix 'ARVS'
 
       requires :token, :patient_id
+      conformance_supports :Observation
 
       test 'Server rejects Vital Signs search without authorization' do
 

--- a/lib/app/views/sequence.erb
+++ b/lib/app/views/sequence.erb
@@ -72,7 +72,7 @@
       </div>
       <div class="sequence-action col-2">
         <%if !sequence_results[sequence_class.sequence_name] && instance.supported_resources.length > 0 && !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
-          <span class="oi oi-warning not-supported-warning" aria-hidden="true" ata-toggle="tooltip" title="The Conformance Statement does not indicate support for the Resources required for this test."></span>
+          <span class="oi oi-warning not-supported-warning" aria-hidden="true" data-toggle="tooltip" title="The Conformance Statement does not indicate support for the Resources required for this test."></span>
         <%end%>
         <span>
           <% #FIXME: Consider ignoring SKIP when displaying the latest sequence result because it shouldn't materially change the current status. %>

--- a/lib/app/views/sequence.erb
+++ b/lib/app/views/sequence.erb
@@ -7,12 +7,7 @@
         <div class='row no-gutters'>
           <% case sequence_results[sequence_class.sequence_name].try(:result)
             when nil %>
-             <% if !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
-                <div class="sequence-score sequence-score-error" data-toggle="tooltip" title="The Conformance Statement does not indicate support for the Resources required for this test.">
-                  <span class="oi oi-warning" aria-hidden="true" ></span>
-                </div>
-              <% end%>
-            <div class='col-11'>
+            <div class='col-12'>
           <% when 'pass' %>
             <div class="sequence-score sequence-score-pass" data-toggle="tooltip" title="Sequence Passed">
               <span class="oi oi-check" aria-hidden="true"></span>
@@ -76,6 +71,9 @@
         </div>
       </div>
       <div class="sequence-action col-2">
+        <%if instance.supported_resources.length > 0 && !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
+          <span class="oi oi-warning not-supported-warning" aria-hidden="true" ata-toggle="tooltip" title="The Conformance Statement does not indicate support for the Resources required for this test."></span>
+        <%end%>
         <span>
           <% #FIXME: Consider ignoring SKIP when displaying the latest sequence result because it shouldn't materially change the current status. %>
           <% if sequence_results[sequence_class.sequence_name]%>

--- a/lib/app/views/sequence.erb
+++ b/lib/app/views/sequence.erb
@@ -7,7 +7,12 @@
         <div class='row no-gutters'>
           <% case sequence_results[sequence_class.sequence_name].try(:result)
             when nil %>
-            <div class='col-12'>
+             <% if !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
+                <div class="sequence-score sequence-score-pass" data-toggle="tooltip" title="Your Conformance says you don't support the required Resources for this test.">
+                  <span class="oi oi-warning" aria-hidden="true" ></span>
+                </div>
+              <% end%>
+            <div class='col-11'>
           <% when 'pass' %>
             <div class="sequence-score sequence-score-pass" data-toggle="tooltip" title="Sequence Passed">
               <span class="oi oi-check" aria-hidden="true"></span>

--- a/lib/app/views/sequence.erb
+++ b/lib/app/views/sequence.erb
@@ -8,7 +8,7 @@
           <% case sequence_results[sequence_class.sequence_name].try(:result)
             when nil %>
              <% if !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
-                <div class="sequence-score sequence-score-pass" data-toggle="tooltip" title="Your Conformance says you don't support the required Resources for this test.">
+                <div class="sequence-score sequence-score-error" data-toggle="tooltip" title="The Conformance Statement does not indicate support for the Resources required for this test.">
                   <span class="oi oi-warning" aria-hidden="true" ></span>
                 </div>
               <% end%>

--- a/lib/app/views/sequence.erb
+++ b/lib/app/views/sequence.erb
@@ -71,7 +71,7 @@
         </div>
       </div>
       <div class="sequence-action col-2">
-        <%if instance.supported_resources.length > 0 && !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
+        <%if !sequence_results[sequence_class.sequence_name] && instance.supported_resources.length > 0 && !sequence_class.conformance_supports.all?{|resource| instance.conformance_supported?(resource)}%>
           <span class="oi oi-warning not-supported-warning" aria-hidden="true" ata-toggle="tooltip" title="The Conformance Statement does not indicate support for the Resources required for this test."></span>
         <%end%>
         <span>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -690,3 +690,11 @@ body {
   transition-delay: 0 !important;
   transition-duration: 0 !important;
 }
+
+.not-supported-warning {
+  font-size: 1.6em !important;
+  opacity: .4;
+  align-items: center;
+  vertical-align: middle;
+  padding-right: 1em;
+}


### PR DESCRIPTION
Adds a warning to users if the Conformance doesn't support the required resource for a sequence. 

Doesn't currently check for operations on those resources. 

<img width="1073" alt="screen shot 2018-10-17 at 3 51 17 pm" src="https://user-images.githubusercontent.com/329127/47113039-f7558500-d225-11e8-823e-1a925f5c58f2.png">
