### PR TITLE
Sequential ids

### DIFF
--- a/lib/app/sequences/06_token_introspection_sequence.rb
+++ b/lib/app/sequences/06_token_introspection_sequence.rb
@@ -169,7 +169,7 @@ module Inferno
       test 'Token introspection response confirms that Refresh token is active' do
 
         metadata {
-          id '06'
+          id '07'
           link 'https://tools.ietf.org/html/rfc7662'
           optional
           desc %(

--- a/lib/app/sequences/07_token_refresh_sequence.rb
+++ b/lib/app/sequences/07_token_refresh_sequence.rb
@@ -120,7 +120,7 @@ module Inferno
       test 'Response includes correct HTTP Cache-Control and Pragma headers' do
 
         metadata {
-          id '10'
+          id '04'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
           desc %(
             The authorization servers response must include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.

--- a/lib/app/sequences/08h_argonaut_observation_sequence.rb
+++ b/lib/app/sequences/08h_argonaut_observation_sequence.rb
@@ -188,7 +188,7 @@ module Inferno
       test 'Observation history resource supported' do
 
         metadata {
-          id '08'
+          id '09'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           optional
           desc %(
@@ -206,7 +206,7 @@ module Inferno
       test 'Observation vread resource supported' do
 
         metadata {
-          id '09'
+          id '10'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           optional
           desc %(
@@ -224,7 +224,7 @@ module Inferno
       test 'Observation Result resources associated with Patient conform to Argonaut profiles' do
 
         metadata {
-          id '10'
+          id '11'
           link 'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html'
           desc %(
             Observation Result resources associated with Patient conform to Argonaut profiles.

--- a/test/unit/sequence_validation_test.rb
+++ b/test/unit/sequence_validation_test.rb
@@ -43,4 +43,22 @@ class SequenceValidationTest < MiniTest::Unit::TestCase
     assert (Inferno::Sequence::SequenceBase.subclasses.select{|seq| !seq.inactive?}-Inferno::Sequence::SequenceBase.ordered_sequences).blank?  && (Inferno::Sequence::SequenceBase.ordered_sequences-Inferno::Sequence::SequenceBase.subclasses.select{|seq| !seq.inactive?}).blank?, 'SequenceBase.ordered_sequences does not contain correct subclasses.  Please update method in SequenceBase.'
   end
 
+  def test_ids_sequential
+
+    # tests ids must be sequential without any holes
+    # test ids must be 2 digits long
+    # if a test is no longer valid, we should add a deprecated flag
+
+    errors = []
+
+    Inferno::Sequence::SequenceBase.subclasses.each do |seq|
+      ids = seq.tests.reduce([]){ |out,hash| out << hash[:test_id].scan(/\d/)[0,2].join.to_i }.sort
+      all_in_order = ids.each_cons(2).all? { |x,y| y == x + 1 }
+      errors << seq.sequence_name unless all_in_order
+    end
+
+    assert errors.empty?, "Sequences #{errors.join(',')} do not have incrementing test id numbers.  Add deprecated flag if a test is no longer needed."
+
+  end
+
 end

--- a/test/unit/sequence_validation_test.rb
+++ b/test/unit/sequence_validation_test.rb
@@ -52,12 +52,19 @@ class SequenceValidationTest < MiniTest::Unit::TestCase
     errors = []
 
     Inferno::Sequence::SequenceBase.subclasses.each do |seq|
-      ids = seq.tests.reduce([]){ |out,hash| out << hash[:test_id].scan(/\d/)[0,2].join.to_i }.sort
+      ids = seq.tests.reduce([]) do |out, hash|
+        if hash[:test_id].nil?
+          out
+        else
+          out << hash[:test_id].scan(/\d{2}/)[0, 2].join.to_i
+        end
+      end.sort
       all_in_order = ids.each_cons(2).all? { |x,y| y == x + 1 }
-      errors << seq.sequence_name unless all_in_order
+      errors << seq.sequence_name unless all_in_order and ids.first != 0
     end
 
-    assert errors.empty?, "Sequences #{errors.join(',')} do not have incrementing test id numbers.  Add deprecated flag if a test is no longer needed."
+    assert errors.empty?, "Sequence(s) #{errors.join(',')} do not have incrementing test id numbers"\
+                          ' or has an id which isn\'t two digits.  Add deprecated flag if a test is no longer needed.'
 
   end
 


### PR DESCRIPTION
Since IDs are 'hardcoded' in a sense, it is easy for them to fall out of sequential order.  We do need them to be hardcoded though to establish traceability across versions from a requirements perspective.  So to help mitigate the problem, this adds a test to make sure that tests ids are sequential and there are no 'holes'.

This test exposed 3 times when this problem occurred, so this PR fixes those instances.

Note: I do not give a solution for when a 'hole' may legitimately exist yet.  We can push that off until it becomes an issue.