### PR TITLE
Token Refresh for Confidential Clients

### DIFF
--- a/lib/app/sequences/03_patient_standalone_launch_sequence.rb
+++ b/lib/app/sequences/03_patient_standalone_launch_sequence.rb
@@ -150,14 +150,13 @@ module Inferno
             'code' => @params['code'],
             'redirect_uri' => @instance.redirect_uris,
         }
+        oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
         if @instance.confidential_client
-          oauth2_headers = {
-              'Authorization' => "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}",
-              'Content-Type' => 'application/x-www-form-urlencoded'
-          }
+          oauth2_headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id +
+                                                                                ':' +
+                                                                                @instance.client_secret)}"
         else
           oauth2_params['client_id'] = @instance.client_id
-          oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
         end
         @token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_headers)
         assert_response_ok(@token_response)

--- a/lib/app/sequences/04_provider_ehr_launch_sequence.rb
+++ b/lib/app/sequences/04_provider_ehr_launch_sequence.rb
@@ -166,7 +166,9 @@ module Inferno
           id '08'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
           desc %(
-            After obtaining an authorization code, the app trades the code for an access token via HTTP POST to the EHR authorization server's token endpoint URL, using content-type application/x-www-form-urlencoded, as described in section 4.1.3 of RFC6749.          )
+            After obtaining an authorization code, the app trades the code for an access token via HTTP POST to the
+            EHR authorization server's token endpoint URL, using content-type application/x-www-form-urlencoded,
+            as described in section [4.1.3 of RFC6749](https://tools.ietf.org/html/rfc6749#section-4.1.3).          )
         }
 
         oauth2_params = {
@@ -174,16 +176,16 @@ module Inferno
             'code' => @params['code'],
             'redirect_uri' => @instance.redirect_uris,
         }
+        oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
         if @instance.confidential_client
-          oauth2_header = {
-              'Authorization' => "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}",
-          }
+          oauth2_headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id +
+                                                                                ':' +
+                                                                                @instance.client_secret)}"
         else
           oauth2_params['client_id'] = @instance.client_id
-          oauth2_header = {}
         end
-        @token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_header)
+        @token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_headers)
         assert_response_ok(@token_response)
 
       end

--- a/lib/app/sequences/07_token_refresh_sequence.rb
+++ b/lib/app/sequences/07_token_refresh_sequence.rb
@@ -6,7 +6,7 @@ module Inferno
       description 'Demonstrate token refresh capability'
       test_id_prefix 'TR'
 
-      requires :refresh_token, :client_id, :oauth_token_endpoint
+      requires :client_id, :confidential_client, :client_secret, :refresh_token, :client_id, :oauth_token_endpoint
 
       test 'Refresh token exchange fails when supplied invalid Refresh Token or Client ID.' do
 
@@ -50,10 +50,18 @@ module Inferno
         oauth2_params = {
             'grant_type' => 'refresh_token',
             'refresh_token' => @instance.refresh_token,
-            'client_id' => @instance.client_id
         }
+        oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
-        @token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params)
+        if @instance.confidential_client
+          oauth2_headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id +
+                                                                                ':' +
+                                                                                @instance.client_secret)}"
+        else
+          oauth2_params['client_id'] = @instance.client_id
+        end
+
+        @token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_headers)
         assert_response_ok(@token_response)
 
       end


### PR DESCRIPTION
Token refresh was failing for confidential clients because it wasn't using the necessary authorization header, this adds that header.