### PR TITLE
Medication Order Test and Fix for Duplicate Orders

### DIFF
--- a/lib/app/models/resource_reference.rb
+++ b/lib/app/models/resource_reference.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Inferno
   module Models
     class ResourceReference
       include DataMapper::Resource
-      property :id, String, key: true, default: proc { SecureRandom.uuid}
+      property :id, String, key: true, default: proc { SecureRandom.uuid }
       property :resource_type, String
       property :resource_id, String
 
@@ -10,4 +12,3 @@ module Inferno
     end
   end
 end
-

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -86,9 +86,11 @@ module Inferno
       end
 
       def patient_id= patient_id
+        return if patient_id.to_s == self.patient_id.to_s
 
         existing_patients = self.resource_references.select{|ref| ref.resource_type == 'Patient'}
-        self.resource_references.each(&:destroy)
+        # Use destroy directly (instead of on each, so we don't have to reload)
+        self.resource_references.destroy
         self.save!
 
         self.resource_references << ResourceReference.new({

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -164,6 +164,19 @@ module Inferno
           end
         end
       end
+
+      def post_resource_references(resource_type: nil, resource_id: nil)
+        self.resource_references.each do |ref|
+          if (ref.resource_type == resource_type) && (ref.resource_id == resource_id)
+            ref.destroy
+          end
+        end
+        self.resource_references << ResourceReference.new({resource_type: resource_type,
+                                                          resource_id: resource_id})
+        self.save!
+        # Ensure the instance resource references are accurate
+        self.reload
+      end
     end
   end
 end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -521,17 +521,9 @@ module Inferno
         entries = reply.resource.entry.select{ |entry| entry.resource.class == klass }
 
         entries.each do |entry|
-          @instance.resource_references.each do |ref|
-            if (ref.resource_type == klass.name.split(':').last) && (ref.resource_id == entry.resource.id)
-              ref.destroy
-            end
-          end
-          @instance.resource_references << Models::ResourceReference.new({resource_type: klass.name.split(':').last, resource_id: entry.resource.id})
+          @instance.post_resource_references(resource_type: klass.name.split(':').last,
+                                             resource_id: entry.resource.id)
         end
-
-        @instance.save!
-        # Ensure the instance resource references are accurate
-        @instance.reload
       end
 
       def validate_read_reply(resource, klass)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -510,16 +510,22 @@ module Inferno
       end
 
       def save_resource_ids_in_bundle(klass, reply)
-
         return if reply.try(:resource).try(:entry).nil?
 
         entries = reply.resource.entry.select{ |entry| entry.resource.class == klass }
 
         entries.each do |entry|
+          @instance.resource_references.each do |ref|
+            if (ref.resource_type == klass.name.split(':').last) && (ref.resource_id == entry.resource.id)
+              ref.destroy
+            end
+          end
           @instance.resource_references << Models::ResourceReference.new({resource_type: klass.name.split(':').last, resource_id: entry.resource.id})
         end
 
         @instance.save!
+        # Ensure the instance resource references are accurate
+        @instance.reload
       end
 
       def validate_read_reply(resource, klass)

--- a/lib/app/sequences/08l_argonaut_medication_order_sequence.rb
+++ b/lib/app/sequences/08l_argonaut_medication_order_sequence.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module Inferno
   module Sequence
     class ArgonautMedicationOrderSequence < SequenceBase
-
       title 'Medication Order'
 
       description 'Verify that MedicationOrder resources on the FHIR server follow the Argonaut Data Query Implementation Guide'
@@ -10,122 +11,134 @@ module Inferno
 
       requires :token, :patient_id
 
-      test 'Server rejects MedicationOrder search without authorization' do
+      details %(
+        # Background
+         The #{title} Sequence tests the [#{title}](https://www.hl7.org/fhir/DSTU2/medicationorder.html)
+        resource provided by a FHIR server.  The #{title} provided must be consistent with the [#{title}
+        Argonaut Profile](https://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html).
 
-        metadata {
+        # Test Methodology
+
+        This test suite accesses the server endpoint at `/MedicationOrder?patient={id}` using a `GET` request.
+        It parses the #{title} and verifies that it contains:
+
+        * The date written
+        * The status of the order
+        * A reference to the patient to whom the medication will be given
+        * A reference to the person authorizing the perscription
+        * A reference or code representing the medication being given
+
+        It collects the following information that is saved in the testing session for use by later tests:
+
+        * List of Medications
+
+        For more information on the #{title}, visit these links:
+
+        * [FHIR DSTU2 #{title}](https://www.hl7.org/fhir/DSTU2/medicationorder.html)
+        * [Argonauts #{title} Profile](https://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html)
+      )
+
+      test 'Server rejects MedicationOrder search without authorization' do
+        metadata do
           id '01'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           desc %(
             An MedicationOrder search does not work without proper authorization.
           )
-        }
+        end
 
-        skip_if_not_supported(:MedicationOrder, [:search, :read])
+        skip_if_not_supported(:MedicationOrder, %i[search read])
 
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
+        reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, patient: @instance.patient_id)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
-
       end
 
       test 'Server returns expected results from MedicationOrder search by patient' do
-
-        metadata {
+        metadata do
           id '02'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           desc %(
             A server is capable of returning a patient's medications.
           )
-        }
+        end
 
-        skip_if_not_supported(:MedicationOrder, [:search, :read])
+        skip_if_not_supported(:MedicationOrder, %i[search read])
 
-        reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
+        reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, patient: @instance.patient_id)
         assert_bundle_response(reply)
 
         @no_resources_found = false
         resource_count = reply.try(:resource).try(:entry).try(:length) || 0
-        if resource_count === 0
-          @no_resources_found = true
-        end
+        @no_resources_found = true if resource_count === 0
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         @medicationorder = reply.try(:resource).try(:entry).try(:first).try(:resource)
         validate_search_reply(FHIR::DSTU2::MedicationOrder, reply)
         save_resource_ids_in_bundle(FHIR::DSTU2::MedicationOrder, reply)
-
       end
 
       test 'MedicationOrder read resource supported' do
-
-        metadata {
+        metadata do
           id '03'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           desc %(
             All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.
           )
-        }
+        end
 
-        skip_if_not_supported(:MedicationOrder, [:search, :read])
+        skip_if_not_supported(:MedicationOrder, %i[search read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_read_reply(@medicationorder, FHIR::DSTU2::MedicationOrder)
-
       end
 
       test 'MedicationOrder history resource supported' do
-
-        metadata {
+        metadata do
           id '04'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           optional
           desc %(
             All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support.
           )
-        }
+        end
 
         skip_if_not_supported(:MedicationOrder, [:history])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_history_reply(@medicationorder, FHIR::DSTU2::MedicationOrder)
-
       end
 
       test 'MedicationOrder vread resource supported' do
-
-        metadata {
+        metadata do
           id '05'
           link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           optional
           desc %(
             All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support.
           )
-        }
+        end
 
         skip_if_not_supported(:MedicationOrder, [:vread])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' if @no_resources_found
 
         validate_vread_reply(@medicationorder, FHIR::DSTU2::MedicationOrder)
-
       end
 
       test 'MedicationOrder resources associated with Patient conform to Argonaut profiles' do
-
-        metadata {
+        metadata do
           id '06'
           link 'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html'
           desc %(
             MedicationOrder resources associated with Patient conform to Argonaut profiles.
           )
-        }
+        end
         test_resources_against_profile('MedicationOrder')
       end
-
     end
-
   end
 end

--- a/test/fixtures/Medication_Reference.json
+++ b/test/fixtures/Medication_Reference.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Medication",
+  "id": "Medication15",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medexample015</p><p><b>contained</b>: , </p><p><b>code</b>: Capecitabine 500mg oral tablet (Xeloda) <span>(Details : {RxNorm code '213293' = '213293', given as 'Capecitabine 500mg oral tablet (Xeloda)'})</span></p><p><b>isBrand</b>: true</p><p><b>manufacturer</b>: id: org2; name: Gene Inc</p><p><b>form</b>: Tablet dose form (qualifier value) <span>(Details : {SNOMED CT code '385055001' = 'Tablet', given as 'Tablet dose form (qualifier value)'})</span></p><h3>Ingredients</h3><table><tr><td>-</td><td><b>Item[x]</b></td><td><b>Amount</b></td></tr><tr><td>*</td><td>id: sub04; Capecitabine (substance) <span>(Details : {SNOMED CT code '386906001' = 'Capecitabine', given as 'Capecitabine (substance)'})</span></td><td>500 mg<span> (Details: UCUM code mg = 'mg')</span>/1 TAB<span> (Details: http://hl7.org/fhir/v3/orderableDrugForm code TAB = 'Tablet')</span></td></tr></table><blockquote><p><b>package</b></p><p><b>container</b>: Bottle - unit of produce usage (qualifier value) <span>(Details : {SNOMED CT code '419672006' = 'Bottle', given as 'Bottle - unit of produce usage (qualifier value)'})</span></p><h3>Contents</h3><table><tr><td>-</td><td><b>Item[x]</b></td></tr><tr><td>*</td><td>Capecitabine 500mg tablets (product) <span>(Details : {SNOMED CT code '134622004' = 'Capecitabine 500mg tablet', given as 'Capecitabine 500mg tablets (product)'})</span></td></tr></table><h3>Batches</h3><table><tr><td>-</td><td><b>LotNumber</b></td><td><b>ExpirationDate</b></td></tr><tr><td>*</td><td>9494788</td><td>22/05/2017</td></tr></table></blockquote></div>"
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "213293",
+        "display": "Capecitabine 500mg oral tablet (Xeloda)"
+      }
+    ]
+  }
+}

--- a/test/fixtures/medication_13.json
+++ b/test/fixtures/medication_13.json
@@ -1,0 +1,62 @@
+{
+  "resourceType": "MedicationOrder",
+  "id": "13",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2009-10-10T12:00:00-05:00"
+  },
+  "status": "active",
+  "patient": {
+    "reference": "Patient/1234"
+  },
+  "prescriber": {
+    "reference": "Practitioner/432"
+  },
+  "dateWritten": "2015-01-15",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "314077",
+        "display": "Lisinopril 20 MG Oral Tablet"
+      }
+    ],
+    "text": "Lisinopril 20 MG Oral Tablet"
+  },
+  "dosageInstruction": [
+    {
+      "text": "1 daily",
+      "timing": {
+        "repeat": {
+          "boundsPeriod": {
+            "start": "2008-08-13"
+          },
+          "frequency": 1,
+          "period": 1,
+          "periodUnits": "d"
+        }
+      },
+      "doseQuantity": {
+        "value": 1,
+        "unit": "{tablet}",
+        "system": "http://unitsofmeasure.org",
+        "code": "{tablet}"
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 90,
+      "unit": "{tablet}",
+      "system": "http://unitsofmeasure.org",
+      "code": "{tablet}"
+    },
+    "expectedSupplyDuration": {
+      "value": 90,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  }
+}

--- a/test/fixtures/medication_14.json
+++ b/test/fixtures/medication_14.json
@@ -1,0 +1,62 @@
+{
+  "resourceType": "MedicationOrder",
+  "id": "14",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2009-10-10T12:00:00-05:00"
+  },
+  "status": "active",
+  "patient": {
+    "reference": "Patient/1234"
+  },
+  "prescriber": {
+    "reference": "Practitioner/432"
+  },
+  "dateWritten": "2015-01-15",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "404673",
+        "display": "Memantine 10 MG Oral Tablet [Namenda]"
+      }
+    ],
+    "text": "Memantine 10 MG Oral Tablet [Namenda]"
+  },
+  "dosageInstruction": [
+    {
+      "text": "1 bid",
+      "timing": {
+        "repeat": {
+          "boundsPeriod": {
+            "start": "2008-08-13"
+          },
+          "frequency": 2,
+          "period": 1,
+          "periodUnits": "d"
+        }
+      },
+      "doseQuantity": {
+        "value": 1,
+        "unit": "{tablet}",
+        "system": "http://unitsofmeasure.org",
+        "code": "{tablet}"
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 180,
+      "unit": "{tablet}",
+      "system": "http://unitsofmeasure.org",
+      "code": "{tablet}"
+    },
+    "expectedSupplyDuration": {
+      "value": 90,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  }
+}

--- a/test/fixtures/medication_15.json
+++ b/test/fixtures/medication_15.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "MedicationOrder",
+  "id": "15",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2009-10-10T12:00:00-05:00"
+  },
+  "status": "active",
+  "patient": {
+    "reference": "Patient/1234"
+  },
+  "prescriber": {
+    "reference": "Practitioner/432"
+  },
+  "dateWritten": "2015-01-15",
+  "medicationReference": {
+    "reference": "Medication/Medication15"
+  },
+  "dosageInstruction": [
+    {
+      "text": "1 bid",
+      "timing": {
+        "repeat": {
+          "boundsPeriod": {
+            "start": "2008-08-13"
+          },
+          "frequency": 2,
+          "period": 1,
+          "periodUnits": "d"
+        }
+      },
+      "doseQuantity": {
+        "value": 1,
+        "unit": "{tablet}",
+        "system": "http://unitsofmeasure.org",
+        "code": "{tablet}"
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 180,
+      "unit": "{tablet}",
+      "system": "http://unitsofmeasure.org",
+      "code": "{tablet}"
+    },
+    "expectedSupplyDuration": {
+      "value": 90,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  }
+}

--- a/test/sequence/medication_order_sequence_test.rb
+++ b/test/sequence/medication_order_sequence_test.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Tests for the Medication Order Sequence
+# It makes sure all the sequences pass and ensures no duplicate resource references occur from multiple runs
+class MedicationOrderSequenceTest < MiniTest::Test
+  def setup
+    @patient_id = 1234
+    @medication_order_bundle = {
+      resourceType: 'Bundle',
+      id: 145,
+      meta: {
+        lastUpdated: '2009-10-10T12:00:00-05:00'
+      },
+      type: 'searchset',
+      total: 2,
+      link: [
+        {
+          relation: 'self',
+          url: "http://www.example.com/MedicationOrder?patient=#{@patient_id}"
+        }
+      ],
+      entry: []
+    }
+
+    @history_bundle = @medication_order_bundle.deep_dup
+    @history_bundle[:type] = 'history'
+    @history_bundle[:total] = 1
+
+    @medication_order13 = load_json_fixture(:medication_13)
+    @medication_order14 = load_json_fixture(:medication_14)
+
+    @medication_order_bundle[:entry] << {
+      resource: @medication_order13,
+      fullUrl: 'http://www.example.com/MedicationOrder/13'
+    }
+    @medication_order_bundle[:entry] << {
+      resource: @medication_order14,
+      fullUrl:  'http://www.example.com/MedicationOrder/14'
+    }
+
+    @instance = Inferno::Models::TestingInstance.new(url: 'http://www.example.com',
+                                                     client_name: 'Inferno',
+                                                     base_url: 'http://localhost:4567',
+                                                     client_endpoint_key: Inferno::SecureRandomBase62.generate(32),
+                                                     client_id: SecureRandom.uuid,
+                                                     oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
+                                                     oauth_token_endpoint: 'http://oauth_reg.example.com/token',
+                                                     scopes: 'launch openid patient/*.* profile',
+                                                     token: 99_897_979)
+
+    @instance.save! # this is for convenience.  we could rewrite to ensure nothing gets saved within tests.
+
+    # Assume we already have a patient
+    @instance.resource_references << Inferno::Models::ResourceReference.new(
+      resource_type: 'Patient',
+      resource_id: @patient_id
+    )
+
+    @instance.supported_resources << Inferno::Models::SupportedResource.create(
+      resource_type: 'MedicationOrder',
+      testing_instance_id: @instance.id,
+      supported: true,
+      read_supported: true,
+      vread_supported: true,
+      search_supported: true,
+      history_supported: true
+    )
+
+    client = FHIR::Client.new(@instance.url)
+    client.use_dstu2
+    client.default_json
+    @sequence = Inferno::Sequence::ArgonautMedicationOrderSequence.new(@instance, client, true)
+  end
+
+  def stub_get_med(med_res)
+    # Getting Medication, must have Authorization Header
+    med_res[:entry].each do |resource|
+      stub_request(:get, resource[:fullUrl])
+        .with(headers: {
+                'Authorization' => "Bearer #{@instance.token}"
+              })
+        .to_return(status: 200,
+                   body: resource[:resource].to_json,
+                   headers: { content_type: 'application/json+fhir; charset=UTF-8' })
+    end
+  end
+
+  def stub_history(med_res)
+    # Getting Medication Resource History, must have Authorization Header
+    med_res[:entry].each do |resource|
+      @history_bundle[:entry] = [{
+        fullUrl: resource[:fullUrl],
+        resource: resource[:resource]
+      }]
+
+      stub_request(:get, resource[:fullUrl] + '/_history')
+        .with(headers: {
+                'Authorization' => "Bearer #{@instance.token}"
+              })
+        .to_return(status: 200,
+                   body: @history_bundle.to_json,
+                   headers: { content_type: 'application/json+fhir; charset=UTF-8' })
+    end
+  end
+
+  def stub_vread(med_res)
+    # Getting Medication Resource History, must have Authorization Header
+    med_res[:entry].each do |resource|
+      stub_request(:get, resource[:fullUrl] + '/_history/1')
+        .with(headers: {
+                'Authorization' => "Bearer #{@instance.token}"
+              })
+        .to_return(status: 200,
+                   body: resource[:resource].to_json,
+                   headers: { content_type: 'application/json+fhir; charset=UTF-8' })
+    end
+  end
+
+  def full_sequence_stubs
+    WebMock.reset!
+    # Return 401 if no Authorization Header
+    stub_request(:get, @medication_order_bundle.dig(:link, 0, :url)).to_return(status: 401)
+
+    # Getting Bundle, must have Authorization Header
+    stub_request(:get, @medication_order_bundle.dig(:link, 0, :url))
+      .with(headers: {
+              'Authorization' => "Bearer #{@instance.token}"
+            })
+      .to_return(status: 200,
+                 body: @medication_order_bundle.to_json,
+                 headers: { content_type: 'application/json+fhir; charset=UTF-8' })
+
+    stub_get_med @medication_order_bundle
+    stub_history @medication_order_bundle
+    stub_vread @medication_order_bundle
+  end
+
+  def test_all_pass
+    full_sequence_stubs
+
+    sequence_result = @sequence.start
+
+    failures = sequence_result.test_results.select { |r| r.result != 'pass' && r.result != 'skip' }
+    assert failures.empty?, "All tests should pass.  First error: #{!failures.empty? && failures.first.message}"
+    assert sequence_result.result == 'pass', 'The sequence should be marked as pass.'
+  end
+
+  def test_no_duplicate_orders
+    full_sequence_stubs
+
+    sequence_result = @sequence.start
+    sequence_result.save!
+
+    puts 'Running second sequence...'
+
+    # When sequences are rerun with the Sinatra Interface new sequences are created
+    client = FHIR::Client.new(@instance.url)
+    client.use_dstu2
+    client.default_json
+    secondInstance = Inferno::Models::TestingInstance.get(@instance[:id])
+    secondInstance.patient_id= @patient_id
+    second_sequence = Inferno::Sequence::ArgonautMedicationOrderSequence.new(secondInstance, client, true)
+    second_sequence.start
+    assert secondInstance.resource_references.length == 3, 'There should only be two reference resources...' \
+                                                      "but #{secondInstance.resource_references.length} were found\n" \
+                                                      "They are: #{secondInstance.resource_references.map do |reference|
+                                                                     reference[:resource_type] + reference[:resource_id]
+                                                                   end.join(', ')} \n" \
+                                                      'Check for duplicates.'
+  end
+end

--- a/test/sequence/token_refresh_sequence_test.rb
+++ b/test/sequence/token_refresh_sequence_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 
 # Test for the Token Refresh Sequence


### PR DESCRIPTION
- Provides testing for the medication order sequence making sure that all tests pass and that no duplicates are present
- Adds some details to the medication order sequence
- Tests all medication orders, not just the first
- Follows medicationReferences, if available