### PR TITLE
TLS not optional

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,7 +18,7 @@ disable_verify_peer: false
 bind: '0.0.0.0'
 
 # Skip TLS tests
-disable_tls_tests: true
+disable_tls_tests: false
 
 # Default scopes
 default_scopes: launch launch/patient offline_access openid profile user/*.* patient/*.*

--- a/lib/app/sequences/01_conformance_sequence.rb
+++ b/lib/app/sequences/01_conformance_sequence.rb
@@ -57,7 +57,6 @@ module Inferno
         metadata {
           id '01'
           link 'https://www.hl7.org/fhir/security.html'
-          optional
           desc %(
             All exchange of production data should be secured with TLS/SSL v1.2.
           )

--- a/lib/app/sequences/02_dynamic_registration_sequence.rb
+++ b/lib/app/sequences/02_dynamic_registration_sequence.rb
@@ -18,7 +18,7 @@ module Inferno
         This sequence tests tests this functionality by dynamically an app for Inferno to use in later sequences.
 
       )
-      
+
       test_id_prefix 'DR'
 
       optional
@@ -31,7 +31,6 @@ module Inferno
         metadata {
           id '01'
           link 'https://www.hl7.org/fhir/security.html'
-          optional
           desc %(
             The client registration endpoint MUST be protected by a transport layer security.
           )

--- a/lib/app/sequences/03_patient_standalone_launch_sequence.rb
+++ b/lib/app/sequences/03_patient_standalone_launch_sequence.rb
@@ -18,7 +18,6 @@ module Inferno
         metadata {
           id '01'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
-          optional
           desc %(
             The client registration endpoint MUST be protected by a transport layer security.
           )
@@ -88,7 +87,6 @@ module Inferno
         metadata {
           id '04'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
-          optional
           desc %(
             Apps must assure that sensitive information (authentication secrets, authorization codes, tokens) is transmitted ONLY to authenticated servers, over TLS-secured channels.
           )

--- a/lib/app/sequences/04_provider_ehr_launch_sequence.rb
+++ b/lib/app/sequences/04_provider_ehr_launch_sequence.rb
@@ -50,7 +50,6 @@ module Inferno
         metadata {
           id '03'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
-          optional
           desc %(
             Apps MUST assure that sensitive information (authentication secrets, authorization codes, tokens) is transmitted ONLY to authenticated servers, over TLS-secured channels.
             opaque identifier for the launch in the launch querystring parameter.
@@ -116,7 +115,6 @@ module Inferno
         metadata {
           id '06'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
-          optional
           desc %(
             Apps MUST assure that sensitive information (authentication secrets, authorization codes, tokens) is transmitted ONLY to authenticated servers, over TLS-secured channels.
           )

--- a/lib/app/sequences/06_token_introspection_sequence.rb
+++ b/lib/app/sequences/06_token_introspection_sequence.rb
@@ -17,7 +17,6 @@ module Inferno
         metadata {
           id '01'
           link 'https://tools.ietf.org/html/rfc7662'
-          optional
           desc %(
             The server MUST support Transport Layer Security (TLS) 1.2.
           )


### PR DESCRIPTION
This resets TLS tests to not being optional.

Note that these were set to being optional in the first place because of a peculiarity when running this on MITRE's network.  When you disable the tls tests through the config, now a 'skip' will get rolled up to the sequence level.  We may consider adding a flag like 'disabled by configuration', which would be more generic and could be useful in the future. 

This also fixes the config and how it was accidentally set to disable tls tests by default during this sprint in an earlier PR.