### PR TITLE
Save client secret to instance state during Manual Registration sequence

### DIFF
--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -140,7 +140,7 @@
         <%# SPECIAL CASE: CLIENT SECRET %>
         <div class="form-group"
           data-requiredby="<%= test_set.variable_required_by(:confidential_client).map {|seq| seq.sequence_name}.join(',')%>"
-          data-prerequisite="confidential_client"
+          data-prerequisite="confidential_client,client_secret"
           id="is_confidential"
           >
           <div class="form-check form-check-inline">

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -283,7 +283,7 @@
         <%# SPECIAL CASE: CLIENT SECRET %>
         <div class="form-group"
           data-requiredby="<%= test_set.variable_required_by(:confidential_client).map {|seq| seq.sequence_name}.join(',')%>"
-          data-prerequisite="confidential_client"
+          data-prerequisite="confidential_client,client_secret"
           id="is_confidential"
           >
           <div class="form-check form-check-inline">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -136,7 +136,7 @@ $(function(){
             })
             if(!alreadyDefined){
               show = true;
-              requirements.push(prerequisite)
+              requirements = requirements.concat(prerequisite.split(','));
             }
           }
         })
@@ -155,11 +155,11 @@ $(function(){
           formInput.find(':radio').each(function(){
             $(this).attr('id', $(this)[0].id + '_active');
           });
-        formInput.find('input')[0].removeAttribute('readonly');
-        formInput.find(':radio:not(:checked)').attr('disabled', false);
-        $('.enabled-prerequisites').append(formInput);
-        $('.enabled-prerequisite-group-title').show();
-        $('.enabled-prerequisites').show();
+          formInput.find('input')[0].removeAttribute('readonly');
+          formInput.find(':radio:not(:checked)').attr('disabled', false);
+          $('.enabled-prerequisites').append(formInput);
+          $('.enabled-prerequisite-group-title').show();
+          $('.enabled-prerequisites').show();
         }
         //$(this).show()
       } else {


### PR DESCRIPTION
Quick fix for #139. A more robust solution might be to recurse through any child `div.form-group`s and collect all the `data-prerequsite`s that way.