### PR TITLE
separate client confidential and client secret prerequisites

### DIFF
--- a/lib/app/modules/smart/dynamic_registration_sequence.rb
+++ b/lib/app/modules/smart/dynamic_registration_sequence.rb
@@ -31,8 +31,8 @@ module Inferno
 
       show_uris
 
-      requires :oauth_register_endpoint, :client_name, :initiate_login_uri, :redirect_uris, :scopes, :confidential_client,:initiate_login_uri, :redirect_uris, :dynamic_registration_token, :client_secret
-      defines :client_id
+      requires :oauth_register_endpoint, :client_name, :initiate_login_uri, :redirect_uris, :scopes, :confidential_client,:initiate_login_uri, :redirect_uris, :dynamic_registration_token
+      defines :client_id, :client_secret
 
       test 'Client registration endpoint secured by transport layer security' do
 

--- a/lib/app/modules/smart/dynamic_registration_sequence.rb
+++ b/lib/app/modules/smart/dynamic_registration_sequence.rb
@@ -31,8 +31,8 @@ module Inferno
 
       show_uris
 
-      requires :oauth_register_endpoint, :client_name, :initiate_login_uri, :redirect_uris, :scopes, :confidential_client,:initiate_login_uri, :redirect_uris, :dynamic_registration_token
-      defines :client_id, :client_secret
+      requires :oauth_register_endpoint, :client_name, :initiate_login_uri, :redirect_uris, :scopes, :confidential_client,:initiate_login_uri, :redirect_uris, :dynamic_registration_token, :client_secret
+      defines :client_id
 
       test 'Client registration endpoint secured by transport layer security' do
 

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -155,17 +155,13 @@
           <div class="form-check form-check-inline" data-requiredby>
             <input class="form-check-input" type="radio" name="confidential_client" id="confidential_client_on" value="true" <%=instance.confidential_client ? "checked" : "" %>>
             <label class="form-check-label" for="confidential_client_on_active">Confidential Client</label>
-          </div>
-
-          <div class="client-secret-container">
-            <%= erb(:prerequisite_field,{},{prerequisite: :client_secret,
-                  label: 'Client Secret',
-                  instance: instance,
-                  value: instance.client_secret}); %>
-          </div>
-          
+          </div>          
         </div>
 
+        <%= erb(:prerequisite_field,{},{prerequisite: :client_secret,
+              label: 'Client Secret',
+              instance: instance,
+              value: instance.client_secret}); %>
         
 
         <%= erb(:prerequisite_field,{},{prerequisite: :client_name,

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -309,17 +309,12 @@
             <input class="form-check-input" type="radio" name="confidential_client" id="confidential_client_on" value="true" <%=instance.confidential_client ? "checked" : "" %>>
             <label class="form-check-label" for="confidential_client_on_active">Confidential Client</label>
           </div>
-
-          <div class="client-secret-container">
-            <%= erb(:prerequisite_field,{},{prerequisite: :client_secret,
-                  label: 'Client Secret',
-                  instance: instance,
-                  value: instance.client_secret}); %>
-          </div>
-          
         </div>
 
-        
+        <%= erb(:prerequisite_field,{},{prerequisite: :client_secret,
+              label: 'Client Secret',
+              instance: instance,
+              value: instance.client_secret}); %>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :client_name,
               label: 'OAuth Client Name',

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -125,9 +125,9 @@ $(function(){
     //$('input[type=radio][name=confidential_client]').on('change', function() {
     $('#PrerequisitesModal').on('change', function(e) {
       if(e.target.id === 'confidential_client_on_active') {
-        $('.client-secret-container').show();
+        $('div[data-prerequisite="client_secret"]').show();
       } else if (e.target.id === 'confidential_client_off_active'){
-        $('.client-secret-container').hide();
+        $('div[data-prerequisite="client_secret"]').hide();
       }
     });
 
@@ -202,9 +202,9 @@ $(function(){
     // Confidential client special case
     
     if($('#confidential_client_on')[0].checked){
-       $('.client-secret-container').show();
+       $('div[data-prerequisite="client_secret"]').show();
     } else {
-       $('.client-secret-container').hide();
+       $('div[data-prerequisite="client_secret"]').hide();
     }
     
 


### PR DESCRIPTION
save client secret during registration by moving it out of the confidential_client prerequisite field.