### PR TITLE
Remove frame option header

### DIFF
--- a/deployment-files/nginx.conf
+++ b/deployment-files/nginx.conf
@@ -49,7 +49,6 @@ http {
     root /var/www/inferno/public;
     # port to listen for requests on
     listen 80;
-
     # maximum accepted body size of client request
     client_max_body_size 4G;
     # the server will close connections after this time

--- a/deployment-files/nginx.conf
+++ b/deployment-files/nginx.conf
@@ -49,6 +49,7 @@ http {
     root /var/www/inferno/public;
     # port to listen for requests on
     listen 80;
+
     # maximum accepted body size of client request
     client_max_body_size 4G;
     # the server will close connections after this time
@@ -67,6 +68,7 @@ http {
       chunked_transfer_encoding off;
       proxy_buffering off;
       proxy_cache off;
+      proxy_hide_header X-Frame-Options;
    
       # the port on ruby_server has to match the EXPOSE in Dockerfile
       proxy_pass http://ruby_server:4567;


### PR DESCRIPTION
Removing the X-Frame-Options header so that inferno can be placed in an iframe.