### PR TITLE
handle redirect when no sequence is being run

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -41,11 +41,12 @@ module Inferno
 
 
           sequence_result = instance.waiting_on_sequence
-          test_set = instance.module.test_sets[sequence_result.test_set_id.to_sym]
-
           if sequence_result.nil? || sequence_result.result != 'wait'
-            redirect "#{BASE_PATH}/#{instance.id}/#{test_set.id}/?error=no_#{params[:endpoint]}"
+            latest_sequence_result = Inferno::Models::SequenceResult.first(:testing_instance => instance)
+            test_set_id = latest_sequence_result.try(:test_set_id) || instance.module.default_test_set
+            redirect "#{BASE_PATH}/#{instance.id}/#{test_set_id}/?error=no_#{params[:endpoint]}"
           else
+            test_set = instance.module.test_sets[sequence_result.test_set_id.to_sym]
             failed_test_cases = []
             all_test_cases = []
             test_case = test_set.test_case_by_id(sequence_result.test_case_id)


### PR DESCRIPTION
This now redirects to the test set of the last run sequence or the default test set. 
Since I couldn't recreate this normally, I just went straight to this url which was able to reproduce the issue.

http://localhost:8080/inferno/oauth2/static/redirect?error=invalid_scope&error_description=Invalid%20scope;%20requested:%5BfhirUser,%20offline_access,%20openid,%20patient/*.read%5D&state={YOUR CLIENT STATE HERE}&scope=launch/patient%20patient/*.read%20openid%20offline_access%20profile%20launch%20user/*.*%20patient/*.*