### PR TITLE
Extend search validation

### DIFF
--- a/lib/app/modules/argonaut/argonaut_allergy_intolerance_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_allergy_intolerance_sequence.rb
@@ -13,6 +13,13 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :AllergyIntolerance
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -71,7 +78,8 @@ module Inferno
           versions :dstu2
         }
 
-        reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -83,7 +91,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @allergyintolerance = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply)
+        validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
@@ -21,10 +21,10 @@ module Inferno
           category = resource.try(:category).try(:coding).try(:first).try(:code)
           assert !category.nil? && category == value, "Category on resource did not match category requested"
         when "date"
-          #todo
+          # todo
         when "status"
           status = resource.try(:status).try(:code)
-          assert !status.nil? && status == value
+          assert !status.nil? && status == value, "Status on resource did not match status requested"
         end
       end
 

--- a/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
@@ -87,7 +87,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careplan = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('CarePlan'), reply)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
+        end
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
 
       end
@@ -112,7 +115,11 @@ module Inferno
         date = @careplan.try(:period).try(:start)
         assert !date.nil?, "CarePlan period not returned"
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan", date: date})
-        validate_search_reply(versioned_resource_class('CarePlan'), reply)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
+          # todo: date
+        end
 
       end
 
@@ -132,7 +139,12 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan", status: "active"})
-        validate_search_reply(versioned_resource_class('CarePlan'), reply)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
+          status = resource.try(:status).try(:code)
+          assert !status.nil? && status == "active"
+        end
 
       end
 
@@ -155,7 +167,13 @@ module Inferno
         date = @careplan.try(:period).try(:start)
         assert !date.nil?, "CarePlan period not returned"
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan", status: "active", date: date})
-        validate_search_reply(versioned_resource_class('CarePlan'), reply)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
+          status = resource.try(:status).try(:code)
+          assert !status.nil? && status == "active"
+          # todo: date
+        end
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
@@ -13,6 +13,21 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :CarePlan
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
+        when "category"
+          category = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == value, "Category on resource did not match category requested"
+        when "date"
+          #todo
+        when "status"
+          status = resource.try(:status).try(:code)
+          assert !status.nil? && status == value
+        end
+      end
+
       details %(
         # Background
 
@@ -75,7 +90,8 @@ module Inferno
 
 
 
-        reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan"})
+        search_params = {patient: @instance.patient_id, category: "assess-plan"}
+        reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -87,10 +103,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careplan = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
-        end
+        validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
 
       end
@@ -114,12 +127,9 @@ module Inferno
 
         date = @careplan.try(:period).try(:start)
         assert !date.nil?, "CarePlan period not returned"
-        reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan", date: date})
-        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
-          # todo: date
-        end
+        search_params = {patient: @instance.patient_id, category: "assess-plan", date: date}
+        reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
       end
 
@@ -138,13 +148,9 @@ module Inferno
         skip_if_not_supported(:CarePlan, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan", status: "active"})
-        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
-          status = resource.try(:status).try(:code)
-          assert !status.nil? && status == "active"
-        end
+        search_params = {patient: @instance.patient_id, category: "assess-plan", status: "active"}
+        reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
       end
 
@@ -166,14 +172,9 @@ module Inferno
         assert !@careplan.nil?, 'Expected valid CarePlan resource to be present'
         date = @careplan.try(:period).try(:start)
         assert !date.nil?, "CarePlan period not returned"
-        reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "assess-plan", status: "active", date: date})
-        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
-          status = resource.try(:status).try(:code)
-          assert !status.nil? && status == "active"
-          # todo: date
-        end
+        search_params = {patient: @instance.patient_id, category: "assess-plan", status: "active", date: date}
+        reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
@@ -16,7 +16,7 @@ module Inferno
       def validate_resource_item (resource, property, value)
         case property
         when "patient"
-          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+          assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
         when "category"
           category = resource.try(:category).try(:coding).try(:first).try(:code)
           assert !category.nil? && category == value, "Category on resource did not match category requested"

--- a/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
@@ -13,6 +13,16 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :CarePlan
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        when "category"
+          category = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == value, "Category on resource did not match category requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -53,12 +63,10 @@ module Inferno
           versions :dstu2
         }
 
-        reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "careteam"})
+        search_params = {patient: @instance.patient_id, category: "careteam"}
+        reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
-        end
+        validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
         # save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
@@ -55,7 +55,10 @@ module Inferno
 
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), {patient: @instance.patient_id, category: "careteam"})
         @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('CarePlan'), reply)
+        validate_search_reply(versioned_resource_class('CarePlan'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "assess-plan", "Category on resource did not match category requested"
+        end
         # save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_condition_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_condition_sequence.rb
@@ -13,6 +13,18 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :Condition
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        when "category"
+          category = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == value, "Category on resource did not match category requested"
+        when "clinicalstatus"
+          #todo
+        end
+      end
+
       details %(
         # Background
 
@@ -75,7 +87,8 @@ module Inferno
 
 
 
-        reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -87,7 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @condition = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Condition'), reply)
+        validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
 
       end
@@ -107,11 +120,9 @@ module Inferno
         skip_if_not_supported(:Condition, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id, clinicalstatus: "active,recurrance,remission"})
-        validate_search_reply(versioned_resource_class('Condition'), reply) do |resource|
-          #todo
-          
-        end
+        search_params = {patient: @instance.patient_id, clinicalstatus: "active,recurrance,remission"}
+        reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
+        validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
       end
 
@@ -130,11 +141,9 @@ module Inferno
         skip_if_not_supported(:Condition, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id, category: "problem"})
-        validate_search_reply(versioned_resource_class('Condition'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "problem", "Category on resource did not match category requested"
-        end
+        search_params = {patient: @instance.patient_id, category: "problem"}
+        reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
+        validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
       end
 
@@ -153,11 +162,9 @@ module Inferno
         skip_if_not_supported(:Condition, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id, category: "health-concern"})
-        validate_search_reply(versioned_resource_class('Condition'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "health-concern", "Category on resource did not match category requested"
-        end
+        search_params = {patient: @instance.patient_id, category: "health-concern"}
+        reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
+        validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_condition_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_condition_sequence.rb
@@ -16,12 +16,11 @@ module Inferno
       def validate_resource_item (resource, property, value)
         case property
         when "patient"
-          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+          assert resource&.patient&.reference&.include?(value), "Patient on resource does not match patient requested"
         when "category"
-          category = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == value, "Category on resource did not match category requested"
+          assert resource&.category&.coding&.any?{|coding| coding.code == value}, "Category on resource did not match category requested"
         when "clinicalstatus"
-          clinicalstatus = resource.try(:clinicalStatus).try(:code) #.code?
+          clinicalstatus = resource&.clinicalStatus
           assert !clinicalstatus.nil? && value.split(',').include?(clinicalstatus), "Clinical status on resource did not match the clinical status requested"
         end
       end
@@ -135,6 +134,11 @@ module Inferno
           optional
           desc %(
             A server SHOULD be capable returning all of a patients problems or all of patients health concerns.
+
+            This test will fail unless the server returns at least one `Condition` in the `problem`
+            category for this patient.  This may be the result of data completeness, and not a true
+            server error.  However, this test is optionalt wi so a test failure will not affect the overall
+            test pass or fail status.
           )
           versions :dstu2
         }
@@ -156,6 +160,11 @@ module Inferno
           optional
           desc %(
             A server SHOULD be capable returning all of a patients problems or all of patients health concerns.
+
+            This test will fail unless the server returns at least one `Condition` in the `health-concern`
+            category for this patient.  This may be the result of data completeness, and not a true
+            server error.  However, this test is optional so a test failure will not affect the overall
+            test pass or fail status.
           )
           versions :dstu2
         }

--- a/lib/app/modules/argonaut/argonaut_condition_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_condition_sequence.rb
@@ -108,7 +108,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id, clinicalstatus: "active,recurrance,remission"})
-        validate_search_reply(versioned_resource_class('Condition'), reply)
+        validate_search_reply(versioned_resource_class('Condition'), reply) do |resource|
+          #todo
+          
+        end
 
       end
 
@@ -128,7 +131,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id, category: "problem"})
-        validate_search_reply(versioned_resource_class('Condition'), reply)
+        validate_search_reply(versioned_resource_class('Condition'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "problem", "Category on resource did not match category requested"
+        end
 
       end
 
@@ -148,7 +154,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         reply = get_resource_by_params(versioned_resource_class('Condition'), {patient: @instance.patient_id, category: "health-concern"})
-        validate_search_reply(versioned_resource_class('Condition'), reply)
+        validate_search_reply(versioned_resource_class('Condition'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "health-concern", "Category on resource did not match category requested"
+        end
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_condition_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_condition_sequence.rb
@@ -21,7 +21,8 @@ module Inferno
           category = resource.try(:category).try(:coding).try(:first).try(:code)
           assert !category.nil? && category == value, "Category on resource did not match category requested"
         when "clinicalstatus"
-          #todo
+          clinicalstatus = resource.try(:clinicalStatus).try(:code) #.code?
+          assert !clinicalstatus.nil? && value.split(',').include?(clinicalstatus), "Clinical status on resource did not match the clinical status requested"
         end
       end
 

--- a/lib/app/modules/argonaut/argonaut_device_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_device_sequence.rb
@@ -13,6 +13,14 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :Device
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+      
+        end
+      end
+
       details %(
         # Background
 
@@ -73,7 +81,8 @@ module Inferno
 
 
 
-        reply = get_resource_by_params(versioned_resource_class('Device'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -85,7 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @device = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Device'), reply)
+        validate_search_reply(versioned_resource_class('Device'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_device_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_device_sequence.rb
@@ -17,7 +17,6 @@ module Inferno
         case property
         when "patient"
           assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
-      
         end
       end
 

--- a/lib/app/modules/argonaut/argonaut_diagnostic_report_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_diagnostic_report_sequence.rb
@@ -21,7 +21,7 @@ module Inferno
           category = resource.try(:category).try(:coding).try(:first).try(:code)
           assert !category.nil? && category == value, "Category on resource did not match category requested"
         when "date"
-          assert resource.effectiveDateTime && resource.effectiveDateTime == value, "EffectiveDateTime on resource did not match date requested"
+          # todo
         when "code"
           code = resource.try(:code).try(:coding).try(:first).try(:code)
           assert !code.nil? && code == value, "Code on resource did not match code requested"

--- a/lib/app/modules/argonaut/argonaut_diagnostic_report_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_diagnostic_report_sequence.rb
@@ -81,7 +81,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+        end
 
       end
 
@@ -103,8 +106,11 @@ module Inferno
         date = @diagnosticreport.try(:effectiveDateTime)
         assert !date.nil?, "DiagnosticReport effectiveDateTime not returned"
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB", date: date})
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply)
-
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
+        end
       end
 
       test 'Server returns expected results from DiagnosticReport search by patient + category + code' do
@@ -124,11 +130,16 @@ module Inferno
         code = @diagnosticreport.try(:code).try(:coding).try(:first).try(:code)
         assert !code.nil?, "DiagnosticReport code not returned"
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB", code: code})
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code_received.nil? && code_received == code, "Category on resource did not match category requested"
+        end
 
       end
 
-      test 'Server returns expected results from DiagnosticReport search by patient + category + code' do
+      test 'Server returns expected results from DiagnosticReport search by patient + category + code + date' do
 
         metadata {
           id '05'
@@ -149,7 +160,13 @@ module Inferno
         date = @diagnosticreport.try(:effectiveDateTime)
         assert !date.nil?, "DiagnosticReport effectiveDateTime not returned"
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB", code: code, date: date})
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code_received.nil? && code_received == code, "Category on resource did not match category requested"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
+        end
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_diagnostic_report_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_diagnostic_report_sequence.rb
@@ -13,6 +13,21 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :DiagnosticReport
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
+        when "category"
+          category = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == value, "Category on resource did not match category requested"
+        when "date"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == value, "EffectiveDateTime on resource did not match date requested"
+        when "code"
+          code = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code.nil? && code == value, "Code on resource did not match code requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -69,7 +84,8 @@ module Inferno
 
 
 
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB"})
+        search_params = {patient: @instance.patient_id, category: "LAB"}
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -81,10 +97,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-        end
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
       end
 
@@ -105,12 +118,9 @@ module Inferno
         assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
         date = @diagnosticreport.try(:effectiveDateTime)
         assert !date.nil?, "DiagnosticReport effectiveDateTime not returned"
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB", date: date})
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
-        end
+        search_params = {patient: @instance.patient_id, category: "LAB", date: date}
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
       end
 
       test 'Server returns expected results from DiagnosticReport search by patient + category + code' do
@@ -129,13 +139,9 @@ module Inferno
         assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
         code = @diagnosticreport.try(:code).try(:coding).try(:first).try(:code)
         assert !code.nil?, "DiagnosticReport code not returned"
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB", code: code})
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
-          assert !code_received.nil? && code_received == code, "Category on resource did not match category requested"
-        end
+        search_params = {patient: @instance.patient_id, category: "LAB", code: code}
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
       end
 
@@ -159,14 +165,9 @@ module Inferno
         assert !code.nil?, "DiagnosticReport code not returned"
         date = @diagnosticreport.try(:effectiveDateTime)
         assert !date.nil?, "DiagnosticReport effectiveDateTime not returned"
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), {patient: @instance.patient_id, category: "LAB", code: code, date: date})
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
-          assert !code_received.nil? && code_received == code, "Category on resource did not match category requested"
-          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
-        end
+        search_params = {patient: @instance.patient_id, category: "LAB", code: code, date: date}
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_goal_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_goal_sequence.rb
@@ -102,7 +102,10 @@ module Inferno
         date = @goal.try(:statusDate) || @goal.try(:targetDate) || @goal.try(:startDate)
         assert !date.nil?, "Goal statusDate, targetDate, nor startDate returned"
         reply = get_resource_by_params(versioned_resource_class('Goal'), {patient: @instance.patient_id, date: date})
-        validate_search_reply(versioned_resource_class('Goal'), reply)
+        validate_search_reply(versioned_resource_class('Goal'), reply) do |resource|
+          date_received = resource.try(:statusDate) || resource.try(:targetDate) || resource.try(:startDate)
+          assert !date_received.nil? && date_received == date
+        end
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_goal_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_goal_sequence.rb
@@ -18,7 +18,7 @@ module Inferno
         when "patient"
           assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
         when "date"
-          date = resource.try(:statusDate) || resource.try(:targetDate) || resource.try(:startDate)
+          date = resource.try(:statusDate) || resource.try(:targetDate) || resource.try(:startDate) #should be targetdate?
           assert !date.nil? && date == value
         end
       end
@@ -110,7 +110,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         assert !@goal.nil?, 'Expected valid Goal resource to be present'
-        date = @goal.try(:statusDate) || @goal.try(:targetDate) || @goal.try(:startDate)
+        date = @goal.try(:statusDate) || @goal.try(:targetDate) || @goal.try(:startDate) #should be targetDate?
         assert !date.nil?, "Goal statusDate, targetDate, nor startDate returned"
         search_params = {patient: @instance.patient_id, date: date}
         reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)

--- a/lib/app/modules/argonaut/argonaut_goal_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_goal_sequence.rb
@@ -13,6 +13,16 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :Goal
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
+        when "date"
+          date = resource.try(:statusDate) || resource.try(:targetDate) || resource.try(:startDate)
+          assert !date.nil? && date == value
+        end
+      end
+
       details %(
         # Background
 
@@ -67,7 +77,8 @@ module Inferno
           versions :dstu2
         }
 
-        reply = get_resource_by_params(versioned_resource_class('Goal'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -79,7 +90,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @goal = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Goal'), reply)
+        validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
 
       end
@@ -101,11 +112,9 @@ module Inferno
         assert !@goal.nil?, 'Expected valid Goal resource to be present'
         date = @goal.try(:statusDate) || @goal.try(:targetDate) || @goal.try(:startDate)
         assert !date.nil?, "Goal statusDate, targetDate, nor startDate returned"
-        reply = get_resource_by_params(versioned_resource_class('Goal'), {patient: @instance.patient_id, date: date})
-        validate_search_reply(versioned_resource_class('Goal'), reply) do |resource|
-          date_received = resource.try(:statusDate) || resource.try(:targetDate) || resource.try(:startDate)
-          assert !date_received.nil? && date_received == date
-        end
+        search_params = {patient: @instance.patient_id, date: date}
+        reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
+        validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_immunization_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_immunization_sequence.rb
@@ -13,6 +13,13 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :Immunization
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -66,7 +73,8 @@ module Inferno
           versions :dstu2
         }
 
-        reply = get_resource_by_params(versioned_resource_class('Immunization'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -78,7 +86,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @immunization = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Immunization'), reply)
+        validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_medication_order_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_medication_order_sequence.rb
@@ -13,6 +13,13 @@ module Inferno
 
       conformance_supports :MedicationOrder
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       details %(
         # Background
          The #{title} Sequence tests the [#{title}](https://www.hl7.org/fhir/DSTU2/medicationorder.html)
@@ -74,7 +81,8 @@ module Inferno
 
         skip_if_not_supported(:MedicationOrder, [:search, :read])
 
-        reply = get_resource_by_params(versioned_resource_class('MedicationOrder'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('MedicationOrder'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -88,7 +96,7 @@ module Inferno
         @medication_orders = reply&.resource&.entry&.map do |med_order|
           med_order&.resource
         end
-        validate_search_reply(versioned_resource_class('MedicationOrder'), reply)
+        validate_search_reply(versioned_resource_class('MedicationOrder'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationOrder'), reply)
       end
 

--- a/lib/app/modules/argonaut/argonaut_medication_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_medication_sequence.rb
@@ -12,6 +12,13 @@ module Inferno
 
       requires :token, :patient_id
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -70,7 +77,8 @@ module Inferno
 
         skip_if_not_supported(:MedicationStatement, [:search, :read])
 
-        reply = get_resource_by_params(versioned_resource_class('MedicationStatement'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('MedicationStatement'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -82,7 +90,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationstatement = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('MedicationStatement'), reply)
+        validate_search_reply(versioned_resource_class('MedicationStatement'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationStatement'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_medication_statement_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_medication_statement_sequence.rb
@@ -12,6 +12,13 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :MedicationStatement
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -66,7 +73,8 @@ module Inferno
 
         skip_if_not_supported(:MedicationStatement, [:search, :read])
 
-        reply = get_resource_by_params(versioned_resource_class('MedicationStatement'), {patient: @instance.patient_id})
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('MedicationStatement'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -80,7 +88,7 @@ module Inferno
         @medication_statements = reply&.resource&.entry&.map do |med_statement|
           med_statement&.resource
         end
-        validate_search_reply(versioned_resource_class('MedicationStatement'), reply)
+        validate_search_reply(versioned_resource_class('MedicationStatement'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationStatement'), reply)
       end
 

--- a/lib/app/modules/argonaut/argonaut_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_observation_sequence.rb
@@ -77,7 +77,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observationresults = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "laboratory", "Category on resource did not match category requested"
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
 
       end
@@ -100,7 +103,11 @@ module Inferno
         date = @observationresults.try(:effectiveDateTime)
         assert !date.nil?, "Observation effectiveDateTime not returned"
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "laboratory", date: date})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "laboratory", "Category on resource did not match category requested"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
+        end
 
       end
 
@@ -122,7 +129,12 @@ module Inferno
         code = @observationresults.try(:code).try(:coding).try(:first).try(:code)
         assert !code.nil?, "Observation code not returned"
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "laboratory", code: code})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "laboratory", "Category on resource did not match category requested"
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code_received.nil? && code_received == code, "Category on resource did not match category requested"
+        end
 
       end
 
@@ -147,7 +159,13 @@ module Inferno
         date = @observationresults.try(:effectiveDateTime)
         assert !date.nil?, "Observation effectiveDateTime not returned"
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "laboratory", code: code, date: date})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "laboratory", "Category on resource did not match category requested"
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code_received.nil? && code_received == code, "Category on resource did not match category requested"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
+        end
 
       end
 
@@ -189,7 +207,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, code: "72166-2"})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          code = @resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code.nil? && code == "72166-2"
+        end
         # TODO check for 72166-2
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
 

--- a/lib/app/modules/argonaut/argonaut_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_observation_sequence.rb
@@ -19,7 +19,7 @@ module Inferno
           category = resource.try(:category).try(:coding).try(:first).try(:code)
           assert !category.nil? && category == value, "Category on resource did not match category requested"
         when "date"
-          assert resource.effectiveDateTime && resource.effectiveDateTime == value, "EffectiveDateTime on resource did not match date requested"
+          # todo
         when "code"
           code = resource.try(:code).try(:coding).try(:first).try(:code)
           assert !code.nil? && code == value, "Code on resource did not match code requested"

--- a/lib/app/modules/argonaut/argonaut_patient_search_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_patient_search_sequence.rb
@@ -11,6 +11,28 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :Patient
 
+      def validate_resource_item(resource, property, value)
+        case property
+        when "identifier"
+          identifier = resource.try(:identifier).try(:first).try(:value)
+          assert !identifier.nil? && identifier == value, "Identifier on resource did not match identifier requested"
+        when "family"
+          family = resource.try(:name).try(:first).try(:family).try(:first)
+          assert !family.nil? && family == value, "Family on resource did not match family requested"
+        when "given"
+          given = resource.try(:name).try(:first).try(:given).try(:first)
+          assert !given.nil? && given == value, "Given name on resource did not match given name requested"
+        when "birthdate"
+          birthdate = resource.try(:birthDate)
+          assert !birthdate.nil? && birthdate == value, "Birthdate on resource did not match birthdate requested"
+        when "gender"
+          gender = resource.try(:gender)
+          assert !gender.nil? && gender = value, "Gnder on resource did not match gender requested"
+        else
+          assert false, property
+        end
+      end
+
       test 'Server rejects patient read without proper authorization' do
 
         metadata {
@@ -153,8 +175,9 @@ module Inferno
         assert !@patient.nil?, 'Expected valid Patient resource to be present'
         identifier = @patient.try(:identifier).try(:first).try(:value)
         assert !identifier.nil?, "Patient identifier not returned"
-        reply = get_resource_by_params(versioned_resource_class('Patient'), {identifier: identifier})
-        validate_search_reply(versioned_resource_class('Patient'), reply)
+        search_params = {identifier: identifier}
+        reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
+        validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
 
       end
 
@@ -176,17 +199,9 @@ module Inferno
         assert !given.nil?, "Patient given name not returned"
         gender = @patient.try(:gender)
         assert !gender.nil?, "Patient gender not returned"
-        reply = get_resource_by_params(versioned_resource_class('Patient'), {family: family, given: given, gender: gender})
-        validate_search_reply(versioned_resource_class('Patient'), reply) do |resource|
-          family_received = resource.try(:name).try(:first).try(:family).try(:first)
-          given_received = resource.try(:name).try(:first).try(:given).try(:first)
-          gender_received = resource.try(:gender)
-
-          assert !family_received.nil? && family_received = family
-          assert !given_received.nil? && given_received = given
-          assert !gender_received.nil? && gender_received = gender
-        end
-
+        search_params = {family: family, given: given, gender: gender}
+        reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
+        validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
       end
 
       test 'Server returns expected results from Patient search by name + birthdate' do
@@ -207,16 +222,9 @@ module Inferno
         assert !given.nil?, "Patient given name not returned"
         birthdate = @patient.try(:birthDate)
         assert !birthdate.nil?, "Patient birthDate not returned"
-        reply = get_resource_by_params(versioned_resource_class('Patient'), {family: family, given: given, birthdate: birthdate})
-        validate_search_reply(versioned_resource_class('Patient'), reply) do |resource|
-          family_received = resource.try(:name).try(:first).try(:family).try(:first)
-          given_received = resource.try(:name).try(:first).try(:given).try(:first)
-          birthdate_received = resource.try(:birthDate)
-
-          assert !family_received.nil? && family_received = family
-          assert !given_received.nil? && given_received = given
-          assert !birthdate_received.nil? && birthdate_received = birthdate
-        end
+        search_params = {family: family, given: given, birthdate: birthdate}
+        reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
+        validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
 
       end
 
@@ -236,14 +244,9 @@ module Inferno
         assert !gender.nil?, "Patient gender not returned"
         birthdate = @patient.try(:birthDate)
         assert !birthdate.nil?, "Patient birthDate not returned"
-        reply = get_resource_by_params(versioned_resource_class('Patient'), {gender: gender, birthdate: birthdate})
-        validate_search_reply(versioned_resource_class('Patient'), reply) do |resource|
-          gender_received = resource.try(:gender)
-          birthdate_received = resource.try(:birthDate)
-
-          assert !gender_received.nil? && gender_received = gender
-          assert !birthdate_received.nil? && birthdate_received = birthdate
-        end
+        search_params = {gender: gender, birthdate: birthdate}
+        reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
+        validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_patient_search_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_patient_search_sequence.rb
@@ -17,19 +17,19 @@ module Inferno
           identifier = resource.try(:identifier).try(:first).try(:value)
           assert !identifier.nil? && identifier == value, "Identifier on resource did not match identifier requested"
         when "family"
-          family = resource.try(:name).try(:first).try(:family).try(:first)
-          assert !family.nil? && family == value, "Family on resource did not match family requested"
+          names = resource.try(:name)
+          assert !names.nil? && names.length > 0, "No names found in patient resource"
+          assert names.any?{|name| name.family.include?(value)}, "Family name on resource did not match family name requested"
         when "given"
-          given = resource.try(:name).try(:first).try(:given).try(:first)
-          assert !given.nil? && given == value, "Given name on resource did not match given name requested"
+          names = resource.try(:name)
+          assert !names.nil? && names.length > 0, "No names found in patient resource"
+          assert names.any?{|name| name.given.include?(value)}, "Family name on resource did not match family name requested"
         when "birthdate"
           birthdate = resource.try(:birthDate)
           assert !birthdate.nil? && birthdate == value, "Birthdate on resource did not match birthdate requested"
         when "gender"
           gender = resource.try(:gender)
-          assert !gender.nil? && gender = value, "Gnder on resource did not match gender requested"
-        else
-          assert false, property
+          assert !gender.nil? && gender == value, "Gender on resource did not match gender requested"
         end
       end
 

--- a/lib/app/modules/argonaut/argonaut_patient_search_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_patient_search_sequence.rb
@@ -177,7 +177,15 @@ module Inferno
         gender = @patient.try(:gender)
         assert !gender.nil?, "Patient gender not returned"
         reply = get_resource_by_params(versioned_resource_class('Patient'), {family: family, given: given, gender: gender})
-        validate_search_reply(versioned_resource_class('Patient'), reply)
+        validate_search_reply(versioned_resource_class('Patient'), reply) do |resource|
+          family_received = resource.try(:name).try(:first).try(:family).try(:first)
+          given_received = resource.try(:name).try(:first).try(:given).try(:first)
+          gender_received = resource.try(:gender)
+
+          assert !family_received.nil? && family_received = family
+          assert !given_received.nil? && given_received = given
+          assert !gender_received.nil? && gender_received = gender
+        end
 
       end
 
@@ -200,7 +208,15 @@ module Inferno
         birthdate = @patient.try(:birthDate)
         assert !birthdate.nil?, "Patient birthDate not returned"
         reply = get_resource_by_params(versioned_resource_class('Patient'), {family: family, given: given, birthdate: birthdate})
-        validate_search_reply(versioned_resource_class('Patient'), reply)
+        validate_search_reply(versioned_resource_class('Patient'), reply) do |resource|
+          family_received = resource.try(:name).try(:first).try(:family).try(:first)
+          given_received = resource.try(:name).try(:first).try(:given).try(:first)
+          birthdate_received = resource.try(:birthDate)
+
+          assert !family_received.nil? && family_received = family
+          assert !given_received.nil? && given_received = given
+          assert !birthdate_received.nil? && birthdate_received = birthdate
+        end
 
       end
 
@@ -221,7 +237,13 @@ module Inferno
         birthdate = @patient.try(:birthDate)
         assert !birthdate.nil?, "Patient birthDate not returned"
         reply = get_resource_by_params(versioned_resource_class('Patient'), {gender: gender, birthdate: birthdate})
-        validate_search_reply(versioned_resource_class('Patient'), reply)
+        validate_search_reply(versioned_resource_class('Patient'), reply) do |resource|
+          gender_received = resource.try(:gender)
+          birthdate_received = resource.try(:birthDate)
+
+          assert !gender_received.nil? && gender_received = gender
+          assert !birthdate_received.nil? && birthdate_received = birthdate
+        end
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_procedure_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_procedure_sequence.rb
@@ -104,7 +104,9 @@ module Inferno
         date = @procedure.try(:performedDateTime) || @procedure.try(:performedPeriod).try(:start)
         assert !date.nil?, "Procedure performedDateTime or performedPeriod not returned"
         reply = get_resource_by_params(versioned_resource_class('Procedure'), {patient: @instance.patient_id, date: date})
-        validate_search_reply(versioned_resource_class('Procedure'), reply)
+        validate_search_reply(versioned_resource_class('Procedure'), reply)do |resource|
+          assert resource.performedDateTime && resource.performedDateTime == date, "performedDateTime on resource did not match date requested"
+        end
 
       end
 

--- a/lib/app/modules/argonaut/argonaut_procedure_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_procedure_sequence.rb
@@ -18,7 +18,7 @@ module Inferno
         when "patient"
           assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
         when "date"
-          assert resource.performedDateTime && resource.performedDateTime == value, "performedDateTime on resource did not match date requested"
+          #todo
         end
       end
 

--- a/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
@@ -64,6 +64,9 @@ module Inferno
 
       end
 
+
+      @resources_found = false
+
       test 'Server returns expected results from Smoking Status search by patient + code' do
 
         metadata {
@@ -77,6 +80,13 @@ module Inferno
 
         search_params = {patient: @instance.patient_id, code: "72166-2"}
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+
+        resource_count = reply.try(:resource).try(:entry).try(:length) || 0
+        if resource_count > 0
+          @resources_found = true
+        end
+
+        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
 

--- a/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
@@ -66,8 +66,10 @@ module Inferno
         }
 
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, code: "72166-2"})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
-        # TODO check for 72166-2
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code_received.nil? && code_received = "72166-2"
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
 
       end

--- a/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
@@ -16,7 +16,7 @@ module Inferno
       def validate_resource_item (resource, property, value)
         case property
         when "patient"
-          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+          assert (resource.subject && resource.subject.reference.include?(value)), "Patient on resource does not match patient requested"
         when "code"
           code = resource.try(:code).try(:coding).try(:first).try(:code)
           assert !code.nil? && code == value, "Code on resource did not match code requested"

--- a/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
@@ -11,6 +11,21 @@ module Inferno
       requires :token, :patient_id
       conformance_supports :Observation
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.subject && resource.subject.reference.include?(value)), "Subject on resource does not match patient requested"
+        when "category"
+          category = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == value, "Category on resource did not match category requested"
+        when "date"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == value, "EffectiveDateTime on resource did not match date requested"
+        when "code"
+          code = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code.nil? && code == value, "Code on resource did not match code requested"
+        end
+      end
+
       details %(
         # Background
 
@@ -65,7 +80,8 @@ module Inferno
           versions :dstu2
         }
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs"})
+        search_params = {patient: @instance.patient_id, category: "vital-signs"}
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
@@ -77,11 +93,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @vitalsigns = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "vital-signs", "Category on resource did not match category requested"
-        end
-        # TODO check for `vital-signs` category
+        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
 
       end
@@ -103,12 +115,9 @@ module Inferno
         assert !@vitalsigns.nil?, 'Expected valid Observation resource to be present'
         date = @vitalsigns.try(:effectiveDateTime)
         assert !date.nil?, "Observation effectiveDateTime not returned"
-        reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs", date: date})
-        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
-        end
+        search_params = {patient: @instance.patient_id, category: "vital-signs", date: date}
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
       end
 
@@ -129,13 +138,9 @@ module Inferno
         assert !@vitalsigns.nil?, 'Expected valid Observation resource to be present'
         code = @vitalsigns.try(:code).try(:coding).try(:first).try(:code)
         assert !code.nil?, "Observation code not returned"
-        reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs", code: code})
-        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
-          assert !code.nil? && code_received = code
-        end
+        search_params = {patient: @instance.patient_id, category: "vital-signs", code: code}
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
       end
 
@@ -158,15 +163,9 @@ module Inferno
         assert !code.nil?, "Observation code not returned"
         date = @vitalsigns.try(:effectiveDateTime)
         assert !date.nil?, "Observation effectiveDateTime not returned"
-        reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs", code: code, date: date})
-        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
-          category  = resource.try(:category).try(:coding).try(:first).try(:code)
-          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
-          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
-          assert !code.nil? && code_received = code
-          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
-        end
-
+        search_params = {patient: @instance.patient_id, category: "vital-signs", code: code, date: date}
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
       end
 
       test 'Vital Signs resources associated with Patient conform to Argonaut profiles' do

--- a/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
@@ -19,7 +19,7 @@ module Inferno
           category = resource.try(:category).try(:coding).try(:first).try(:code)
           assert !category.nil? && category == value, "Category on resource did not match category requested"
         when "date"
-          assert resource.effectiveDateTime && resource.effectiveDateTime == value, "EffectiveDateTime on resource did not match date requested"
+          # todo
         when "code"
           code = resource.try(:code).try(:coding).try(:first).try(:code)
           assert !code.nil? && code == value, "Code on resource did not match code requested"

--- a/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
@@ -77,7 +77,10 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @vitalsigns = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "vital-signs", "Category on resource did not match category requested"
+        end
         # TODO check for `vital-signs` category
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
 
@@ -101,7 +104,11 @@ module Inferno
         date = @vitalsigns.try(:effectiveDateTime)
         assert !date.nil?, "Observation effectiveDateTime not returned"
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs", date: date})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
+        end
 
       end
 
@@ -123,7 +130,12 @@ module Inferno
         code = @vitalsigns.try(:code).try(:coding).try(:first).try(:code)
         assert !code.nil?, "Observation code not returned"
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs", code: code})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code.nil? && code_received = code
+        end
 
       end
 
@@ -147,7 +159,13 @@ module Inferno
         date = @vitalsigns.try(:effectiveDateTime)
         assert !date.nil?, "Observation effectiveDateTime not returned"
         reply = get_resource_by_params(versioned_resource_class('Observation'), {patient: @instance.patient_id, category: "vital-signs", code: code, date: date})
-        validate_search_reply(versioned_resource_class('Observation'), reply)
+        validate_search_reply(versioned_resource_class('Observation'), reply) do |resource|
+          category  = resource.try(:category).try(:coding).try(:first).try(:code)
+          assert !category.nil? && category == "LAB", "Category on resource did not match category requested"
+          code_received = resource.try(:code).try(:coding).try(:first).try(:code)
+          assert !code.nil? && code_received = code
+          assert resource.effectiveDateTime && resource.effectiveDateTime == date, "EffectiveDateTime on resource did not match date requested"
+        end
 
       end
 

--- a/lib/app/modules/bluebutton_demo/bluebutton_explanationofbenefit_sequence.rb
+++ b/lib/app/modules/bluebutton_demo/bluebutton_explanationofbenefit_sequence.rb
@@ -12,6 +12,13 @@ module Inferno
 
       requires :token, :patient_id
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       test 'Server rejects ExplanationOfBenefit search without authorization' do
 
         metadata {
@@ -45,8 +52,9 @@ module Inferno
 
         skip_if_not_supported(:ExplanationOfBenefit, [:search, :read])
 
-        reply = get_resource_by_params(versioned_resource_class('ExplanationOfBenefit'), {patient: @instance.patient_id})
-        validate_search_reply(versioned_resource_class('ExplanationOfBenefit'), reply)
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(versioned_resource_class('ExplanationOfBenefit'), search_params)
+        validate_search_reply(versioned_resource_class('ExplanationOfBenefit'), reply, search_params)
         save_resource_ids_in_bundle(versioned_resource_class('ExplanationOfBenefit'), reply)
 
       end

--- a/lib/app/modules/onc_program/document_reference_sequence.rb
+++ b/lib/app/modules/onc_program/document_reference_sequence.rb
@@ -14,6 +14,13 @@ module Inferno
 
       description 'Tests for DocumentReference resources'
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "patient"
+          assert (resource.patient && resource.patient.reference.include?(value)), "Patient on resource does not match patient requested"
+        end
+      end
+
       test 'Server rejects DocumentReference search without authorization' do
         metadata do
           id '01'
@@ -41,9 +48,10 @@ module Inferno
           )
         end
 
-        reply = get_resource_by_params(FHIR::DSTU2::DocumentReference, patient: @instance.patient_id)
+        search_params = {patient: @instance.patient_id}
+        reply = get_resource_by_params(FHIR::DSTU2::DocumentReference, search_params)
         @document_reference = reply.try(:resource).try(:entry).try(:first).try(:resource)
-        validate_search_reply(FHIR::DSTU2::DocumentReference, reply)
+        validate_search_reply(FHIR::DSTU2::DocumentReference, reply, search_params)
       end
 
       test 'DocumentReference read resource supported' do

--- a/lib/app/modules/onc_program/provenance_sequence.rb
+++ b/lib/app/modules/onc_program/provenance_sequence.rb
@@ -14,6 +14,13 @@ module Inferno
 
       description 'Tests for Provenance resources'
 
+      def validate_resource_item (resource, property, value)
+        case property
+        when "target"
+          assert (resource.target && resource.target.any?{|t| t.reference.include?(@instance.patient_id)}), "No target on resource matches patient requested"
+        end
+      end
+
       test 'Server rejects Provenance search without authorization' do
         metadata do
           id '01'
@@ -45,8 +52,9 @@ module Inferno
           )
         end
 
-        reply = get_resource_by_params(FHIR::DSTU2::Provenance, target: "Patient/" + @instance.patient_id)
-        validate_search_reply(FHIR::DSTU2::Provenance, reply)
+        search_params = {target: "Patient/" + @instance.patient_id}
+        reply = get_resource_by_params(FHIR::DSTU2::Provenance, search_params)
+        validate_search_reply(FHIR::DSTU2::Provenance, reply, search_params)
         @provenance = reply.try(:resource).try(:entry).try(:first).try(:resource)
 
         assert !@provenance.nil?, 'Expected valid DSTU2 Provenance resource to be present'

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -7,32 +7,32 @@ require_relative 'utils/validation'
 require_relative 'utils/walk'
 require_relative 'utils/web_driver'
 
-require 'bloomer'
-require 'bloomer/msgpackable'
-require 'json'
+# require 'bloomer'
+# require 'bloomer/msgpackable'
+# require 'json'
 
 module Inferno
   module Sequence
 
-    bloomfilter_root = "data/umls-bloomer-bloom-filters"
-    vs_bloomfilter_manifest_path = "#{bloomfilter_root}/manifest.json"
+    # bloomfilter_root = "data/umls-bloomer-bloom-filters"
+    # vs_bloomfilter_manifest_path = "#{bloomfilter_root}/manifest.json"
 
-    if File.file? vs_bloomfilter_manifest_path
-      vs_bloomfilter_manifest = JSON.parse(File.read(vs_bloomfilter_manifest_path))
-      vs_bloomfilter_manifest["filters"].each do |filter_detail|
-        vs_url = filter_detail.fetch("valueSetUrl", nil)
-        next unless vs_url
+    # if File.file? vs_bloomfilter_manifest_path
+    #   vs_bloomfilter_manifest = JSON.parse(File.read(vs_bloomfilter_manifest_path))
+    #   vs_bloomfilter_manifest["filters"].each do |filter_detail|
+    #     vs_url = filter_detail.fetch("valueSetUrl", nil)
+    #     next unless vs_url
 
-        filename = "#{bloomfilter_root}/#{filter_detail['file']}"
-        one_filter = Bloomer::Scalable.from_msgpack(open(filename).read())
-        validate_fn = lambda do |coding|
-          probe = "#{coding.system}|#{coding.code}"
-          one_filter.include? probe
-        end
+    #     filename = "#{bloomfilter_root}/#{filter_detail['file']}"
+    #     one_filter = Bloomer::Scalable.from_msgpack(open(filename).read())
+    #     validate_fn = lambda do |coding|
+    #       probe = "#{coding.system}|#{coding.code}"
+    #       one_filter.include? probe
+    #     end
 
-        FHIR::DSTU2::StructureDefinition.validates_vs(vs_url, &validate_fn)
-      end
-    end
+    #     FHIR::DSTU2::StructureDefinition.validates_vs(vs_url, &validate_fn)
+    #   end
+    # end
 
     class SequenceBase
 
@@ -579,6 +579,7 @@ module Inferno
         elsif ['CarePlan', 'Goal', 'DiagnosticReport', 'Observation', 'Procedure', 'DocumentReference', 'Composition'].map{|type| versioned_resource_class(type)}.include?(klass)
           entries.each do |entry|
             assert (entry.resource.subject && entry.resource.subject.reference.include?(@instance.patient_id)), "Subject on resource does not match patient requested"
+            yield entry.resource if block_given?
           end
         else
           entries.each do |entry|


### PR DESCRIPTION
I'm adding a validate_resource_item function in each sequence that does a validate_search_reply. This makes it so each sequence has a way to validate search results based on its own structure. 

I still need to implement the date check, but I'm not sure how to check if a date time falls within a period. It should be easy to add later though. Not sure if this is time-sensitive so just creating a pull request now.

Things I'm not sure about: 
It looks like clinicalStatus in the condition resource should be a code, but in HSPC it's just a string.
Argonaut says category is a valid search parameter for careplan, but FHIR DSTU2 says it isn't. 