### PR TITLE
make fhir_server url required

### DIFF
--- a/lib/app/views/index.erb
+++ b/lib/app/views/index.erb
@@ -31,7 +31,7 @@
       <div class="form-group">
         <label for="fhir_server" class="endpoint-label sr-only">FHIR Server Endpoint</label>
         <div class="input-group">
-          <input type="url" class="form-control form-control-lg" name="fhir_server" placeholder="http://your-fhir-server.org" aria-label="Create App">
+          <input type="url" required class="form-control form-control-lg" name="fhir_server" placeholder="http://your-fhir-server.org" aria-label="Create App">
           <div class="input-group-btn">
             <button class="btn btn-lg btn-secondary" type="submit">Begin</button>
           </div>


### PR DESCRIPTION
Makes entering a FHIR server URL mandatory:

Before:
![url_before](https://user-images.githubusercontent.com/41651655/54033492-6eae9580-4182-11e9-9c92-f65799847fec.gif)

After:
![url_after](https://user-images.githubusercontent.com/41651655/54034272-740cdf80-4184-11e9-9eda-ba0e24e888bb.gif)