### PR TITLE
Add inferno instance uri to report.

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -232,7 +232,8 @@ module Inferno
             supported_resources: instance.supported_resources.count,
             request_response: request_response_count,
             latest_sequence_time: latest_sequence_time,
-            final_result: instance.final_result
+            final_result: instance.final_result,
+            inferno_url: "#{request.base_url}#{base_path}/#{instance.id}/#{params[:test_set]}/"
           }
           
           erb :report, {:layout => false}, instance: instance,  test_set:test_set, show_button: false, sequence_results:sequence_results, report_summary:report_summary

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -238,7 +238,10 @@
                   <a class="sequence-anchor"></a>
                 <h1>
                   <%= instance.module.title %> Report
-                  <div class="group-steps"> Step <span class="group-step-number"><%=instance.group_results(test_set.id).length %></span> of <%= instance.group_results(test_set.id).length %></div>
+                  <button class="btn print-button" onclick="window.print()">
+                    <span class="oi oi-print" aria-hidden="true"></span>
+                    Print
+                  </button>
                 </h1>
                 <div id="reportDiv">
                 </div>

--- a/lib/app/views/report.erb
+++ b/lib/app/views/report.erb
@@ -3,11 +3,13 @@
     <div class="sequence-title container">
       <span class="sequence-name">
         Report Summary
-        </span>
-        <span class="sequence-out-of">
-          - <%=report_summary[:latest_sequence_time] %>
-        </span>
-        <button class="btn print-button" onclick="window.print()">Print</button>
+      </span>
+      <span class="sequence-out-of">
+        - <%=report_summary[:latest_sequence_time] %>
+      </span>
+      <div class="report-url">
+        <%= "#{report_summary[:inferno_url]}" %>
+      </div>
     </div>
     <div class="container text-center">
       <div class="row">

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -571,6 +571,7 @@ body {
 .sequence-out-of {
   display: inline-block;
   color: #666;
+  font-size: .9rem;
 }
 
 .sequence-details {
@@ -1137,7 +1138,8 @@ body {
 
 .report-url {
   float: right;
-  font-size: .8rem;
+  font-size: .9rem;
+  color: #666;
 }
 
 #reportDiv h3 {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1103,7 +1103,7 @@ body {
 
   position:absolute;
   top: 10px;
-  right: 15px;
+  right: 25px;
   border: 1px solid #aaa;
 }
 
@@ -1135,6 +1135,11 @@ body {
   display:none;
 }
 
+.report-url {
+  float: right;
+  font-size: .8rem;
+}
+
 #reportDiv h3 {
   margin-top: 20px;
   margin-top: 10px;
@@ -1145,7 +1150,7 @@ body {
 }
 
 @media print{
-  .guided-background-fill, .footer, .server-info, .group-nav, .inferno-header{
+  .guided-background-fill, .footer, .server-info, .group-nav, .inferno-header, .print-button{
     display:none;
   }
 


### PR DESCRIPTION
It would be useful to see in the report which operational system performed the tests, and be able to get back to the live instance.  This adds the URI to the report.

It also fixes a bug where on the report section, the report stated 'Step 4 of 4' incorrectly.

![screen shot 2019-03-08 at 11 38 31 am](https://user-images.githubusercontent.com/412901/54042006-23eb4880-4197-11e9-8a51-1a6cb1fabb46.png)
