### PR TITLE
open failed sequences correctly

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -155,6 +155,7 @@ module Inferno
                   count += 1
                   out << js_update_result(sequence, test_set, result, count, sequence.test_count)
                 end
+                all_test_cases << test_case.id
                 if sequence_result.result == 'fail' || sequence_result.result == 'error' then
                   failed_test_cases << test_case.id
                 end


### PR DESCRIPTION
To reproduce, run the standalone launch sequence in the ONC module. The failed tests should be open and not just the first sequence. 