### PR TITLE
display fhir version

### DIFF
--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -1,7 +1,9 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
-  <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
+  <% if instance.module.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
+    <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
+  <% end %>
   </div>
 </div>
 

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -1,6 +1,7 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
+  <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
   </div>
 </div>
 

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -2,7 +2,7 @@
   <div id="header-module-name">
   <%=instance.module.title%>
   <% if instance.module.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
-    <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
+    <span class='badge badge-dark'>FHIR <%=instance.module.fhir_version.upcase%></span>
   <% end %>
   </div>
 </div>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -1,7 +1,9 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
-  <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
+  <% if instance.module.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
+    <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
+  <% end %>
   </div>
 </div>
 

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -1,6 +1,7 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
+  <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
   </div>
 </div>
 

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -2,7 +2,7 @@
   <div id="header-module-name">
   <%=instance.module.title%>
   <% if instance.module.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
-    <span class='badge badge-dark'><%=instance.module.fhir_version.upcase%></span>
+    <span class='badge badge-dark'>FHIR <%=instance.module.fhir_version.upcase%></span>
   <% end %>
   </div>
 </div>

--- a/lib/app/views/module_options.erb
+++ b/lib/app/views/module_options.erb
@@ -8,7 +8,7 @@
       <label class="form-check-label" for="<%=mod.name %>">
       <%=mod.title %>
       <% if mod.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
-        <span class='badge badge-dark'><%=mod.fhir_version.upcase%></span>
+        <span class='badge badge-dark'>FHIR <%=mod.fhir_version.upcase%></span>
       <% end %>
       </label>
     </div>

--- a/lib/app/views/module_options.erb
+++ b/lib/app/views/module_options.erb
@@ -7,6 +7,9 @@
       <input class="form-check-input" type="radio" name="module" value="<%=mod.name %>" id="<%=mod.name %>" <% if index == 0 %>checked<% end %>>
       <label class="form-check-label" for="<%=mod.name %>">
       <%=mod.title %>
+      <% if mod.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
+        <span class='badge badge-dark'><%=mod.fhir_version.upcase%></span>
+      <% end %>
       </label>
     </div>
   <% end %>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -99,6 +99,12 @@ body {
   color: #444;
 }
 
+#header-module-name .badge{
+  font-size: 0.75rem;
+  background-color: #999;
+  top: -60px;
+}
+
 .server-actions {
   text-align: right;
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -102,7 +102,6 @@ body {
 #header-module-name .badge{
   font-size: 0.75rem;
   background-color: #999;
-  top: -60px;
 }
 
 .server-actions {
@@ -155,6 +154,11 @@ body {
 
 .index-page .form-check{
   font-size: 1.3rem;
+}
+
+.form-check .badge{
+  font-size: 0.75rem;
+  background-color: #999;
 }
 
 .index-page h2 {


### PR DESCRIPTION
Displayed FHIR version in the heading:
![fhir version](https://user-images.githubusercontent.com/47094547/58345386-31bf7a00-7e26-11e9-811b-9176ce08686c.PNG)

And on the index page: 
![start testing](https://user-images.githubusercontent.com/47094547/58345255-e9a05780-7e25-11e9-8bcb-d01fcc29b07a.PNG)

But not for SMART: 
![smart](https://user-images.githubusercontent.com/47094547/58345268-ee650b80-7e25-11e9-8b19-0b16493c8e9a.PNG)