### PR TITLE
Made fhir version optional

### DIFF
--- a/lib/app/modules/onc_program_module.yml
+++ b/lib/app/modules/onc_program_module.yml
@@ -1,5 +1,5 @@
 name: onc
-title: Proposed ONC Health IT Certification Tests (FHIR DSTU2)
+title: Proposed ONC Health IT Certification Tests
 description: |
 
   The Program Edition is designed to verify that the developers’ FHIR server meet the standards requirements currently

--- a/lib/app/modules/onc_program_r4_module.yml
+++ b/lib/app/modules/onc_program_r4_module.yml
@@ -1,5 +1,5 @@
 name: onc_r4
-title: Preliminary ONC Health IT Certification Tests (FHIR R4)
+title: Preliminary ONC Health IT Certification Tests
 
 description : |
 

--- a/lib/app/modules/smart/smart_discovery_sequence.rb
+++ b/lib/app/modules/smart/smart_discovery_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         assert capabilities.kind_of?(Array), 'The capabilities response is not an array'
       end
 
-      test 'Conformance Statement provides OAuth 2.0 endpoints' do
+      test 'Conformance/Capability Statement provides OAuth 2.0 endpoints' do
 
         metadata {
           id '02'
@@ -80,12 +80,11 @@ module Inferno
         }
 
         @conformance = @client.conformance_statement
-        assert @conformance.class == versioned_conformance_class, 'Expected valid Conformance resource'
         oauth_metadata = @client.get_oauth2_metadata_from_conformance(false) # strict mode off, don't require server to state smart conformance
-        assert !oauth_metadata.nil?, 'No OAuth Metadata in conformance statement'
+        assert !oauth_metadata.nil?, 'No OAuth Metadata in Conformance/CapabiliytStatemeent resource'
         @conformance_authorize_url = oauth_metadata[:authorize_url]
         @conformance_token_url = oauth_metadata[:token_url]
-        assert !@conformance_authorize_url.blank?, 'No authorize URI provided in conformance statement.'
+        assert !@conformance_authorize_url.blank?, 'No authorize URI provided in Conformance/CapabilityStatement resource'
         assert (@conformance_authorize_url =~ /\A#{URI::regexp(['http', 'https'])}\z/) == 0, "Invalid authorize url: '#{@conformance_authorize_url}'"
         assert !@conformance_token_url.blank?, 'No token URI provided in conformance statement.'
         assert (@conformance_token_url =~ /\A#{URI::regexp(['http', 'https'])}\z/) == 0, "Invalid token url: '#{@conformance_token_url}'"
@@ -100,8 +99,8 @@ module Inferno
               end
             end
 
-          assert !service.empty?, 'No security services listed. Conformance.rest.security.service should be SMART-on-FHIR.'
-          assert service.any? {|any_service| any_service == 'SMART-on-FHIR'}, "Conformance.rest.security.service set to #{service.map{ |e| "'" + e + "'" }.join(', ')}.  It should contain 'SMART-on-FHIR'."
+          assert !service.empty?, 'No security services listed. Conformance/CapabilityStatement.rest.security.service should be SMART-on-FHIR.'
+          assert service.any? {|any_service| any_service == 'SMART-on-FHIR'}, "Conformance/CapabilityStatement.rest.security.service set to #{service.map{ |e| "'" + e + "'" }.join(', ')}.  It should contain 'SMART-on-FHIR'."
         }
 
         registration_url = nil

--- a/lib/app/modules/smart_module.yml
+++ b/lib/app/modules/smart_module.yml
@@ -1,7 +1,6 @@
 name: smart
 title: SMART Application Launch Framework Implementation Guide v1.0.0
 description: Smart on FHIR Testing
-fhir_version: dstu2
 default_test_set: developer
 test_sets:
   developer:

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -432,7 +432,7 @@ module Inferno
                                           test_index: test_index)
           begin
 
-            skip_unless((@@test_metadata[self.sequence_name][test_index_in_sequence][:versions].include? @instance.fhir_version.to_sym), 'This test does not run with this FHIR version')
+            skip_unless((@@test_metadata[self.sequence_name][test_index_in_sequence][:versions].include? @instance.fhir_version&.to_sym), 'This test does not run with this FHIR version') unless @instance.fhir_version.nil?
             Inferno.logger.info "Starting Test: #{@@test_metadata[self.sequence_name][test_index_in_sequence][:test_id]} [#{name}]"
             instance_eval &block
 

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -1,7 +1,7 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
-  <% if instance.module.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
+  <% if instance.module.fhir_version != nil %>
     <span class='badge badge-dark'>FHIR <%=instance.module.fhir_version.upcase%></span>
   <% end %>
   </div>

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -1,7 +1,7 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
-  <% if instance.module.fhir_version != nil %>
+  <% unless instance.module.fhir_version.nil? %>
     <span class='badge badge-dark'>FHIR <%=instance.module.fhir_version.upcase%></span>
   <% end %>
   </div>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -1,7 +1,7 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
-  <% if instance.module.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
+  <% if instance.module.fhir_version != nil %>
     <span class='badge badge-dark'>FHIR <%=instance.module.fhir_version.upcase%></span>
   <% end %>
   </div>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -1,7 +1,7 @@
 <div class="container" role='main'>
   <div id="header-module-name">
   <%=instance.module.title%>
-  <% if instance.module.fhir_version != nil %>
+  <% unless instance.module.fhir_version.nil? %>
     <span class='badge badge-dark'>FHIR <%=instance.module.fhir_version.upcase%></span>
   <% end %>
   </div>

--- a/lib/app/views/module_options.erb
+++ b/lib/app/views/module_options.erb
@@ -7,7 +7,7 @@
       <input class="form-check-input" type="radio" name="module" value="<%=mod.name %>" id="<%=mod.name %>" <% if index == 0 %>checked<% end %>>
       <label class="form-check-label" for="<%=mod.name %>">
       <%=mod.title %>
-      <% if mod.title != "SMART Application Launch Framework Implementation Guide v1.0.0" %>
+      <% if mod.fhir_version != nil %>
         <span class='badge badge-dark'>FHIR <%=mod.fhir_version.upcase%></span>
       <% end %>
       </label>

--- a/lib/app/views/module_options.erb
+++ b/lib/app/views/module_options.erb
@@ -7,7 +7,7 @@
       <input class="form-check-input" type="radio" name="module" value="<%=mod.name %>" id="<%=mod.name %>" <% if index == 0 %>checked<% end %>>
       <label class="form-check-label" for="<%=mod.name %>">
       <%=mod.title %>
-      <% if mod.fhir_version != nil %>
+      <% unless mod.fhir_version.nil? %>
         <span class='badge badge-dark'>FHIR <%=mod.fhir_version.upcase%></span>
       <% end %>
       </label>

--- a/lib/app/views/state_status.erb
+++ b/lib/app/views/state_status.erb
@@ -7,7 +7,7 @@
       </div>
     </div>
 
-    <% if instance.fhir_version != nil %>
+    <% unless instance.fhir_version.nil? %>
       <div class="form-group row">
         <label class="col-sm-2 col-form-label">FHIR Version</label>
         <div class="col-sm-10">

--- a/lib/app/views/state_status.erb
+++ b/lib/app/views/state_status.erb
@@ -7,12 +7,14 @@
       </div>
     </div>
 
-    <div class="form-group row">
-      <label class="col-sm-2 col-form-label">FHIR Version</label>
-      <div class="col-sm-10">
-        <input type="text" class="form-control" value="<%=instance.fhir_version.upcase %>" disabled>
+    <% if instance.fhir_version != nil %>
+      <div class="form-group row">
+        <label class="col-sm-2 col-form-label">FHIR Version</label>
+        <div class="col-sm-10">
+          <input type="text" class="form-control" value="<%=instance.fhir_version.upcase %>" disabled>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <h4>Conformance Statement Resource Support</h4>
     <% if instance.supported_resources.count > 0%>


### PR DESCRIPTION
The fhir_version field in the yml files for configuring modules is now optional. If this field is filled, then the FHIR version is displayed on the index page, header, and in the state popup box. For example, the SMART module does not have a fhir_version. Also, the FHIR version was removed from the module titles. 

Index page: 
![start](https://user-images.githubusercontent.com/47094547/58355553-b91ae680-7e42-11e9-97c7-cf55e6988c3b.PNG)

Header: 
![header on](https://user-images.githubusercontent.com/47094547/58353534-b87f5180-7e3c-11e9-9643-a4365d1a833f.PNG)
![header off](https://user-images.githubusercontent.com/47094547/58353526-b3220700-7e3c-11e9-915a-35f8c2845f19.PNG)

State popup box: 
![state on](https://user-images.githubusercontent.com/47094547/58353556-c208b980-7e3c-11e9-8318-c58ceed4c5d7.PNG) 

![state off](https://user-images.githubusercontent.com/47094547/58353569-ccc34e80-7e3c-11e9-81d9-619505da198b.PNG)

