### PR TITLE
WIP: Fix CareTeam test in DSTU2

### DIFF
--- a/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
@@ -70,9 +70,15 @@ module Inferno
 
         search_params = {patient: @instance.patient_id, category: "careteam"}
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
+        resource_count = reply.try(:resource).try(:entry).try(:length) || 0
+        if resource_count > 0
+          @resources_found = true
+        end
+
+        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
         @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
-        # save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
 
       end
 
@@ -102,7 +108,7 @@ module Inferno
           versions :dstu2
         }
 
-        skip_if_not_supported(:CareTeam, [:search, :read])
+        skip_if_not_supported(:CarePlan, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@careteam)

--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -81,7 +81,7 @@ module Inferno
             elsif resource.category && resource.category.coding && resource.category.coding.any? { |coding| coding.code == 'vital-signs' }
               return DEFINITIONS[ARGONAUT_URIS[:vital_signs]]
             end
-          elsif resource.resourceType == 'CareTeam'
+          elsif resource.resourceType == 'CarePlan'
             if resource.category && resource.category.coding && resource.category.coding.any? { |coding| coding.code = 'careteam' }
               return DEFINITIONS[ARGONAUT_URIS[:care_team]]
             else

--- a/test/fixtures/care_team.json
+++ b/test/fixtures/care_team.json
@@ -2,7 +2,7 @@
   "id": "85e027e0-103b-0136-6943-60f81dc2d82a",
   "meta": {
     "profile": [
-      "http://fhir.org/guides/argonaut/StructureDefinition/argo-careplan"
+      "http://fhir.org/guides/argonaut/StructureDefinition/argo-careteam"
     ]
   },
   "text": {

--- a/test/fixtures/care_team.json
+++ b/test/fixtures/care_team.json
@@ -1,0 +1,60 @@
+{
+  "id": "85e027e0-103b-0136-6943-60f81dc2d82a",
+  "meta": {
+    "profile": [
+      "http://fhir.org/guides/argonaut/StructureDefinition/argo-careplan"
+    ]
+  },
+  "text": {
+    "status": "additional",
+    "div": "This example is modified from the Official Argonaut Implementation Guide at http://www.fhir.org/guides/argonaut/r2/CarePlan-colonoscopy.html"
+  },
+  "subject": {
+    "reference": "Patient/7ec866ca-4130-4a40-82a9-b67f2626a5df",
+    "display": "Mrs. Rhea34 Ernser583"
+  },
+  "status": "active",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://argonaut.hl7.org/ValueSet/extension-codes",
+          "code": "careteam"
+        }
+      ]
+    }
+  ],
+  "participant": [
+    {
+      "role": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "116154003",
+            "display": "Patient (person)"
+          }
+        ]
+      },
+      "member": {
+        "reference": "Patient/7ec866ca-4130-4a40-82a9-b67f2626a5df",
+        "display": "Mrs. Rhea34 Ernser583"
+      }
+    },
+    {
+      "role": {
+        "coding": [
+          {
+            "system": "http://www.nucc.org",
+            "code": "207RC0000X",
+            "display": "Allopathic and Osteopathic Physicians:Internal Medicine:Cardiovascular Disease"
+          }
+        ]
+      },
+      "member": {
+        "reference": "Practitioner/1",
+        "display": "Dr. Cayr (BMC PCP)"
+      }
+    }
+  ],
+  "resourceType": "CarePlan"
+}

--- a/test/sequence/argonaut/argonaut_careteam_sequence_test.rb
+++ b/test/sequence/argonaut/argonaut_careteam_sequence_test.rb
@@ -1,14 +1,14 @@
 
 
 require_relative '../../test_helper'      
-class CarePlanSequenceTest < MiniTest::Test 
+class CareTeamSequenceTest < MiniTest::Test 
     
     def setup
         @instance = get_test_instance
         client = get_client(@instance)
 
-        @fixture = "care_plan" #put fixture file name here
-        @sequence = Inferno::Sequence::ArgonautCarePlanSequence.new(@instance, client) #put sequence here
+        @fixture = "care_team" #put fixture file name here
+        @sequence = Inferno::Sequence::ArgonautCareTeamSequence.new(@instance, client) #put sequence here
         @resource_type = "CarePlan"
 
         @resource = FHIR::DSTU2.from_contents(load_fixture(@fixture.to_sym))
@@ -30,7 +30,7 @@ class CarePlanSequenceTest < MiniTest::Test
         resource_type: 'Patient',
         resource_id: @patient_id
         )
-
+        
         # Register that the server supports MedicationStatement
         if !@instance.resource_references.any? {|r| r.resource_type == @resource_type }
             @instance.supported_resources << Inferno::Models::SupportedResource.create(
@@ -63,7 +63,7 @@ class CarePlanSequenceTest < MiniTest::Test
 
     def full_sequence_stubs
         # Return 401 if no Authorization Header
-        uri_template = Addressable::Template.new "http://www.example.com/#{@resource_type}{?patient,target,start,end,userid,agent}"
+        uri_template = Addressable::Template.new "http://www.example.com/#{@resource_type}{?patient,category}"
         stub_request(:get, uri_template).to_return(status: 401)
 
         # Search Resources

--- a/test/sequence/argonaut/argonaut_careteam_sequence_test.rb
+++ b/test/sequence/argonaut/argonaut_careteam_sequence_test.rb
@@ -103,6 +103,11 @@ class CareTeamSequenceTest < MiniTest::Test
             .to_return(status: 200,
                         body: @patient_resource.to_json,
                         headers: { content_type: 'application/json+fhir; charset=UTF-8'})
+        stub_request(:get, %r{example.com/Practitioner/1})
+            .with(headers: @extended_request_headers)
+            .to_return(status: 200,
+                        body: @patient_resource.to_json,
+                                    headers: { content_type: 'application/json+fhir; charset=UTF-8'})
     end
     
     def test_all_pass
@@ -112,6 +117,9 @@ class CareTeamSequenceTest < MiniTest::Test
 
         failures = sequence_result.test_results.select { |r| r.result != 'pass' && r.result != 'skip' }
         assert failures.empty?, "All tests should pass.  First error: #{!failures.empty? && failures.first.message}"
+        sequence_result.test_results.each do |test_result|
+            assert test_result.result == 'pass', "#{test_result.name} - #{test_result.result}"
+        end
         assert sequence_result.result == 'pass', "The sequence should be marked as pass. #{sequence_result.result}"
         assert sequence_result.test_results.all? { |r| r.test_warnings.empty? }, 'There should not be any warnings.'
     end

--- a/test/sequence/argonaut/argonaut_careteam_sequence_test.rb
+++ b/test/sequence/argonaut/argonaut_careteam_sequence_test.rb
@@ -123,6 +123,39 @@ class CareTeamSequenceTest < MiniTest::Test
         assert sequence_result.result == 'pass', "The sequence should be marked as pass. #{sequence_result.result}"
         assert sequence_result.test_results.all? { |r| r.test_warnings.empty? }, 'There should not be any warnings.'
     end
+
+    # Return a careplan profiled resource even though we are asking for a careteam profile
+    # This should have at least one failure
+    def test_fail_on_wrong_profile
+        full_sequence_stubs
+
+        # Return the wrong profile
+        uri_template = Addressable::Template.new "http://www.example.com/#{@resource_type}{?patient,category}"
+        wrong_resource = FHIR::DSTU2.from_contents(load_fixture("care_plan"))
+
+        # set the careteam category, even though this is a careplan profiled resource
+        wrong_resource.category.first.coding.first.code = 'careteam'
+        
+        wrong_resource_bundle = wrap_resources_in_bundle(wrong_resource)
+
+        wrong_resource_bundle.entry.each do |entry|
+            entry.resource.meta = FHIR::DSTU2::Meta.new unless entry.resource.meta
+            entry.resource.meta.versionId = '1'
+        end
+
+        stub_request(:get, uri_template)
+            .with(headers: @request_headers)
+            .to_return(
+            status: 200, body: wrong_resource_bundle.to_json, headers: @response_headers
+            )
+
+        sequence_result = @sequence.start
+
+        failures = sequence_result.test_results.select { |r| r.result != 'pass' && r.result != 'skip' }
+        assert !failures.empty?, "Expecting at least one failure because we are returning a resource stating conformance to the wrong profile"
+        assert sequence_result.result == 'fail', "The sequence should be marked as fail. #{sequence_result.result}"
+        assert sequence_result.test_results.all? { |r| r.test_warnings.empty? }, 'There should not be any warnings.'
+    end
 end
         
         


### PR DESCRIPTION
CareTeam incorrectly skips on a correctly behaving server.  This is because how we handle references and guess_profile for resources that could match multiple profiles.  I added a test that shows the issue in this PR to start.

![Screen Shot 2019-05-28 at 2 24 10 PM](https://user-images.githubusercontent.com/412901/58502376-65671080-8154-11e9-9e68-25c8fbbc9fc6.png)
