### PR TITLE
added more instruction to EHR launch tests

### DIFF
--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -290,6 +290,14 @@
         </div>
         <div class="modal-body">
           <p>
+          <strong>
+          To continue the test, initiate an app launch outside of Inferno from the EHR. 
+          </strong>
+          </p>
+          <p>
+          Inferno is waiting at the specified launch point for the launch sequence to be initiated. The test will continue running with the information provided during the launch from the EHR.
+          </p>
+          <p>
           Waiting for server to send client browser to <strong><%= waiting_on_sequence.wait_at_endpoint.upcase %></strong> URI:
           </p>
           <textarea class="form-control" rows=1 readonly><%=redirect_to %></textarea>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -441,6 +441,14 @@
         </div>
         <div class="modal-body">
           <p>
+          <strong>
+          To continue the test, initiate an app launch outside of Inferno from the EHR. 
+          </strong>
+          </p>
+          <p>
+          Inferno is waiting at the specified launch point for the launch sequence to be initiated. The test will continue running with the information provided during the launch from the EHR.
+          </p>
+          <p>
           Waiting for server to send client browser to <strong><%= waiting_on_sequence.wait_at_endpoint.upcase %></strong> URI:
           </p>
           <textarea class="form-control" rows=1 readonly><%=redirect_to %></textarea>


### PR DESCRIPTION
Added more explanation and instruction to the EHR pop up for the EHR Launch tests. 
<img width="798" alt="Screen Shot 2019-05-29 at 10 59 21 AM" src="https://user-images.githubusercontent.com/47094547/58567723-d3691180-8200-11e9-9872-9767dbbeca49.png">