### PR TITLE
Check for valid JSON

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,7 +64,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 194
+  Max: 199
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.

--- a/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
@@ -71,7 +71,7 @@ module Inferno
         search_params = { patient: @instance.patient_id, category: 'careteam' }
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         resource_count = reply.try(:resource).try(:entry).try(:length) || 0
-        @resources_found = true if resource_count > 0
+        @resources_found = true if resource_count.positive?
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
         @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)

--- a/lib/app/modules/smart/ehr_launch_sequence.rb
+++ b/lib/app/modules/smart/ehr_launch_sequence.rb
@@ -209,6 +209,7 @@ module Inferno
         end
 
         @token_response_headers = @token_response.headers
+        assert_valid_json(@token_response.body)
         @token_response_body = JSON.parse(@token_response.body)
 
         assert @token_response_body.key?('access_token'), 'Token response did not contain access_token as required'

--- a/lib/app/modules/smart/standalone_launch_sequence.rb
+++ b/lib/app/modules/smart/standalone_launch_sequence.rb
@@ -186,6 +186,7 @@ module Inferno
         end
 
         @token_response_headers = @token_response.headers
+        assert_valid_json(@token_response.body)
         @token_response_body = JSON.parse(@token_response.body)
 
         if @token_response_body.key?('id_token')

--- a/lib/app/modules/smart/token_refresh_sequence.rb
+++ b/lib/app/modules/smart/token_refresh_sequence.rb
@@ -93,6 +93,7 @@ module Inferno
         end
 
         @token_response_headers = @token_response.headers
+        assert_valid_json(@token_response.body)
         @token_response_body = JSON.parse(@token_response.body)
 
         assert @token_response_body.key?('access_token'), 'Token response did not contain access_token as required'

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -7,6 +7,12 @@ module Inferno
       raise AssertionException.new message, data unless test
     end
 
+    def assert_valid_json(json)
+      JSON.parse(json)
+    rescue JSON::ParserError
+      raise AssertionException, 'Invalid JSON'
+    end
+
     def assert_equal(expected, actual, message = '', data = '')
       unless assertion_negated(expected == actual)
         message += " Expected: #{expected}, but found: #{actual}."


### PR DESCRIPTION
Added checking for valid JSON to smart sequences token refresh, EHR launch, and standalone launch sequence. 

<img width="916" alt="Screen Shot 2019-06-04 at 1 32 37 PM" src="https://user-images.githubusercontent.com/47094547/58900485-41b04700-86cd-11e9-9c1a-e28ee7e9baea.png">
<img width="914" alt="Screen Shot 2019-06-04 at 1 32 44 PM" src="https://user-images.githubusercontent.com/47094547/58900491-42e17400-86cd-11e9-9c2b-582361e4ee92.png">