### PR TITLE
Try Me Base URL

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,6 +58,14 @@ presets:
     client_id: vkPKDPcTIEMaw5Uf-DdUUtNMFMZaX0
     client_secret: LS1nY3JFU3FDeEs0cWoxQWF6TVJFNU05RmZZNGZhZ2Vwb2JYWjdSWWJGakwwNTZ2Vng=
     instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions
+  site_test_healthit_gov:
+    name: SITE FHIR Sandbox
+    uri: https://fhir.sitenv.org/secure/fhir
+    module: onc
+    inferno_uri: https://infernotest.healthit.gov
+    client_id: TrToU5piE-dJ1g6PBG1elFV4r9KLmH
+    client_secret: ckFqb1ZhbmFMQS13WDE0c1dTLWxSdGRLSE8yUXpWNS1vSnd6azNrMmU3Y0JPdDRja3U=
+    instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions
   site_local: 
     name: SITE FHIR Sandbox
     uri: https://fhir.sitenv.org/secure/fhir

--- a/config.yml
+++ b/config.yml
@@ -48,12 +48,21 @@ modules:
   - us_core_r4
   - argonaut
 
-# preset fhir servers: optional. Minimally requires name, uri, module, optional client_id, client_secret, scopes, instructions link
+# preset fhir servers: optional. Minimally requires name, uri, module, optional domain, client_id, client_secret, scopes, instructions link
 presets:
   site_healthit_gov: 
     name: SITE FHIR Sandbox
     uri: https://fhir.sitenv.org/secure/fhir
     module: onc
+    domain: https://inferno.healthit.gov/inferno/
     client_id: vkPKDPcTIEMaw5Uf-DdUUtNMFMZaX0
     client_secret: LS1nY3JFU3FDeEs0cWoxQWF6TVJFNU05RmZZNGZhZ2Vwb2JYWjdSWWJGakwwNTZ2Vng=
+    instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions
+  site_local: 
+    name: SITE FHIR Sandbox
+    uri: https://fhir.sitenv.org/secure/fhir
+    module: onc
+    domain: http://localhost:4567
+    client_id: Yg0o6sJ8I8CfVVyHz1eA0m8jv6sXwe
+    client_secret: UDVrTXlna0NvcGRQZ1VhMkZaZzQ0R1FxVGdtTWxFMXVoT3pPd1VRMUN4MFVkV25Gejk=
     instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions

--- a/config.yml
+++ b/config.yml
@@ -48,13 +48,13 @@ modules:
   - us_core_r4
   - argonaut
 
-# preset fhir servers: optional. Minimally requires name, uri, module, optional domain, client_id, client_secret, scopes, instructions link
+# preset fhir servers: optional. Minimally requires name, uri, module, optional inferno_uri, client_id, client_secret, scopes, instructions link
 presets:
   site_healthit_gov: 
     name: SITE FHIR Sandbox
     uri: https://fhir.sitenv.org/secure/fhir
     module: onc
-    domain: https://inferno.healthit.gov/inferno/
+    inferno_uri: https://inferno.healthit.gov/inferno/
     client_id: vkPKDPcTIEMaw5Uf-DdUUtNMFMZaX0
     client_secret: LS1nY3JFU3FDeEs0cWoxQWF6TVJFNU05RmZZNGZhZ2Vwb2JYWjdSWWJGakwwNTZ2Vng=
     instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions
@@ -62,7 +62,7 @@ presets:
     name: SITE FHIR Sandbox
     uri: https://fhir.sitenv.org/secure/fhir
     module: onc
-    domain: http://localhost:4567
+    inferno_uri: http://localhost:4567
     client_id: Yg0o6sJ8I8CfVVyHz1eA0m8jv6sXwe
     client_secret: UDVrTXlna0NvcGRQZ1VhMkZaZzQ0R1FxVGdtTWxFMXVoT3pPd1VRMUN4MFVkV25Gejk=
     instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions

--- a/config.yml
+++ b/config.yml
@@ -54,7 +54,7 @@ presets:
     name: SITE FHIR Sandbox
     uri: https://fhir.sitenv.org/secure/fhir
     module: onc
-    inferno_uri: https://inferno.healthit.gov/inferno/
+    inferno_uri: https://inferno.healthit.gov
     client_id: vkPKDPcTIEMaw5Uf-DdUUtNMFMZaX0
     client_secret: LS1nY3JFU3FDeEs0cWoxQWF6TVJFNU05RmZZNGZhZ2Vwb2JYWjdSWWJGakwwNTZ2Vng=
     instructions: https://github.com/siteadmin/inferno/wiki/SITE-Preset-Instructions

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -54,7 +54,7 @@ module Inferno
 
       def render_index
         unless defined?(settings.presets).nil? || settings.presets.nil? # rubocop:disable Style/IfUnlessModifier
-          presets = settings.presets.select { |_, v| v['domain'].nil? || v['domain'] == request.base_url }
+          presets = settings.presets.select { |_, v| v['inferno_uri'].nil? || v['inferno_uri'] == request.base_url }
         end
         modules = settings.modules.map { |m| Inferno::Module.get(m) }.compact
         erb :index, {}, modules: modules, presets: presets

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -53,8 +53,14 @@ module Inferno
       set(:prefix) { '/' << name[/[^:]+$/].underscore }
 
       def render_index
-        unless defined?(settings.presets).nil? || settings.presets.nil? # rubocop:disable Style/IfUnlessModifier
-          presets = settings.presets.select { |_, v| v['inferno_uri'].nil? || v['inferno_uri'] == request.base_url }
+        unless defined?(settings.presets).nil? || settings.presets.nil?
+          base_url = request.base_url
+          base_path = Inferno::BASE_PATH.chomp('/') unless Inferno::BASE_PATH.nil?
+
+          presets = settings.presets.select do |_, v|
+            inferno_uri = v['inferno_uri'].chomp('/') unless v['inferno_uri'].nil?
+            inferno_uri.nil? || inferno_uri == base_url || inferno_uri == base_url + base_path
+          end
         end
         modules = settings.modules.map { |m| Inferno::Module.get(m) }.compact
         erb :index, {}, modules: modules, presets: presets

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -51,6 +51,14 @@ module Inferno
       set :static, true
       set :views, File.expand_path('views', __dir__)
       set(:prefix) { '/' << name[/[^:]+$/].underscore }
+
+      def render_index
+        unless defined?(settings.presets).nil? || settings.presets.nil? # rubocop:disable Style/IfUnlessModifier
+          presets = settings.presets.select { |_, v| v['domain'].nil? || v['domain'] == request.base_url }
+        end
+        modules = settings.modules.map { |m| Inferno::Module.get(m) }.compact
+        erb :index, {}, modules: modules, presets: presets
+      end
     end
   end
 end

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -55,10 +55,10 @@ module Inferno
       def render_index
         unless defined?(settings.presets).nil? || settings.presets.nil?
           base_url = request.base_url
-          base_path = Inferno::BASE_PATH.chomp('/') unless Inferno::BASE_PATH.nil?
+          base_path = Inferno::BASE_PATH&.chomp('/')
 
           presets = settings.presets.select do |_, v|
-            inferno_uri = v['inferno_uri'].chomp('/') unless v['inferno_uri'].nil?
+            inferno_uri = v['inferno_uri']&.chomp('/')
             inferno_uri.nil? || inferno_uri == base_url || inferno_uri == base_url + base_path
           end
         end

--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -11,10 +11,7 @@ module Inferno
 
         # Return the index page of the application
         get '/?' do
-          unless defined?(settings.presets).nil? || settings.presets.nil?
-            presets = Hash[settings.presets.map { |k, v| [k, v] if v['domain'].nil? || v['domain'] == request.base_url }]
-          end
-          erb :index, {}, modules: settings.modules.map { |m| Inferno::Module.get(m) }.compact, presets: presets
+          render_index
         end
 
         # Returns the static files associated with web app

--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -11,7 +11,10 @@ module Inferno
 
         # Return the index page of the application
         get '/?' do
-          erb :index, {}, modules: settings.modules.map { |m| Inferno::Module.get(m) }.compact, presets: defined?(settings.presets).nil? ? nil : settings.presets
+          unless defined?(settings.presets).nil? || settings.presets.nil?
+            presets = Hash[settings.presets.map { |k, v| [k, v] if v['domain'].nil? || v['domain'] == request.base_url }]
+          end
+          erb :index, {}, modules: settings.modules.map { |m| Inferno::Module.get(m) }.compact, presets: presets
         end
 
         # Returns the static files associated with web app

--- a/lib/app/endpoint/landing.rb
+++ b/lib/app/endpoint/landing.rb
@@ -11,10 +11,7 @@ module Inferno
         # Return the index page of the application
         get '/' do
           logger.info 'loading index page.'
-          unless defined?(settings.presets).nil? || settings.presets.nil?
-            presets = Hash[settings.presets.map { |k, v| [k, v] if v['domain'].nil? || v['domain'] == request.base_url }]
-          end
-          erb :index, {}, modules: settings.modules.map { |m| Inferno::Module.get(m) }.compact, presets: presets
+          render_index
         end
 
         get '/landing/?' do

--- a/lib/app/endpoint/landing.rb
+++ b/lib/app/endpoint/landing.rb
@@ -11,7 +11,10 @@ module Inferno
         # Return the index page of the application
         get '/' do
           logger.info 'loading index page.'
-          erb :index, {}, modules: settings.modules.map { |m| Inferno::Module.get(m) }.compact, presets: defined?(settings.presets).nil? ? nil : settings.presets
+          unless defined?(settings.presets).nil? || settings.presets.nil?
+            presets = Hash[settings.presets.map { |k, v| [k, v] if v['domain'].nil? || v['domain'] == request.base_url }]
+          end
+          erb :index, {}, modules: settings.modules.map { |m| Inferno::Module.get(m) }.compact, presets: presets
         end
 
         get '/landing/?' do

--- a/lib/app/views/index.erb
+++ b/lib/app/views/index.erb
@@ -39,7 +39,7 @@
 
       </div>
 
-      <% if !presets.blank? %>
+      <% if presets.present? %>
         <% module_names = Array.new(modules.length).map!.with_index{ |mod, i| modules[i].name } %>
         <div class="form-group">
           <span class="oi oi-lightbulb"></span> Optionally, choose a preset vendor configuration to test:

--- a/lib/app/views/index.erb
+++ b/lib/app/views/index.erb
@@ -39,7 +39,7 @@
 
       </div>
 
-      <% if !presets.nil? %>
+      <% if !presets.blank? %>
         <% module_names = Array.new(modules.length).map!.with_index{ |mod, i| modules[i].name } %>
         <div class="form-group">
           <span class="oi oi-lightbulb"></span> Optionally, choose a preset vendor configuration to test:

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -342,7 +342,7 @@ $(function(){
   // Then register the handler
   $(window).on('scroll', handleScroll)
 
-  $('#preset-select').on('change', function(e, preset_id = "") {
+  function handlePresetChange(e, preset_id = ""){
     preset_id = preset_id == "" ? $('#preset-select option:selected').data('selected') : preset_id;
     var all = $('#preset-select option:selected').data('all');
     var modules = $('#preset-select option:selected').data('module_names').split(",");
@@ -358,18 +358,23 @@ $(function(){
     var preset_on = $el.val() == '' ? false : true;
 
     if (preset_on) {
-      modules.forEach(mod => document.getElementById(mod).disabled = true);
+      modules.forEach(function(mod){document.getElementById(mod).disabled = true});
       document.getElementById(preset.module).checked = true;
       document.getElementById(preset.module).disabled = false;
       document.getElementById("preset").value = JSON.stringify(preset);
       document.getElementById("instructions-link").style.display = preset.instructions == null ? "none" : "";
       document.getElementById("instructions-link").href = preset.instructions;
     } else {
-      modules.forEach(mod => document.getElementById(mod).disabled = false);
+      modules.forEach(function(mod){document.getElementById(mod).disabled = false});
       document.getElementById("preset").value = "";
       document.getElementById("instructions-link").style.display = "none";
     }
-  })
+  }
+
+  // Call when we initially load
+  handlePresetChange();
+  // Set handler
+  $('#preset-select').on('change', handlePresetChange);
 
   if (window.location.hash != "") {
     var preset_id = window.location.hash;


### PR DESCRIPTION
Adding a "domain" field to the presets in the config file will cause that preset to only appear if the base url of the current url is the same as the domain in the config file. If there is no domain specified in the config file, then the preset will always appear. This allows the presets to be configured for both localhost and for inferno.healthit.gov. 

These are the two base urls: 
https://inferno.healthit.gov/inferno/ (this one should be double checked)
http://localhost:4567