### PR TITLE
Add Continue button for guided tests 

### DIFF
--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -158,75 +158,69 @@
 
                   <% end %>
 
-                  <% case group_result.to_s
+                  <div class="group-message">
+                    <% case group_result.to_s
                       when 'pass' %>
-                      <div class="group-message">
-                        Result: Pass. Tests have successfully passed.
-                      </div>
-                      <%= markdown_to_html(group.overview) %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-loop"></span> Rerun All Tests
-                      </button>
-                    <% when 'fail' %>
-                      <div class="group-message">
-                        Result: Fail. One or more tests have failed, please see below for failure details.
-                      </div>
-                      <%= markdown_to_html(group.overview) %>
-                      <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
-                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
-                          <span class="oi oi-loop"></span> Rerun Skipped Tests
-                        </button>
+                          Result: Pass. Tests have successfully passed.
+                      <% when 'fail' %>
+                          Result: Fail. One or more tests have failed, please see below for failure details.
+                      <% when 'cancel' %>
+                          Cancelled
+                      <% when 'error' %>
+                          Errored
+                      <% when 'wait' %>
+                          Paused
+                      <% when 'skip' %>
+                          Skipped
                       <% end %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-loop"></span> Rerun All Tests
-                      </button>
-                    <% when 'cancel' %>
-                      <div class="group-message">
-                        Cancelled
-                      </div>
-                      <%= markdown_to_html(group.overview) %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Begin Tests
-                      </button>
-                    <% when 'error' %>
-                      <div class="group-message">
-                        Errored
-                      </div>
-                      <%= markdown_to_html(group.overview) %>
-                      <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
-                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
-                          <span class="oi oi-loop"></span> Rerun Skipped Tests
+                  </div>
+                  <%= markdown_to_html(group.overview) %>
+
+                  <div class='buttons-container'>
+                    <% case group_result.to_s
+                      when 'pass' %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-loop"></span> Rerun All Tests
                         </button>
-                      <% end %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-loop"></span> Rerun All Tests
-                      </button>
-                    <% when 'wait' %>
-                      <div class="group-message">
-                        Paused
-                      </div>
-                      <%= markdown_to_html(group.overview) %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Begin Tests
-                      </button>
-                    <% when 'skip' %>
-                        <div class="group-message">
-                        Skipped
-                      </div>
-                      <%= markdown_to_html(group.overview) %>
-                      <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
-                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
-                          <span class="oi oi-loop"></span> Rerun Skipped Tests
+                      <% when 'fail' %>
+                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
+                          <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
+                            <span class="oi oi-loop"></span> Rerun Skipped Tests
+                          </button>
+                        <% end %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-loop"></span> Rerun All Tests
                         </button>
-                      <% end %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-loop"></span> Rerun All Tests
-                      </button>
-                    <% else %>
-                      <%= markdown_to_html(group.overview) %>
-                      <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Run
-                      </button>
+                      <% when 'cancel' %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-media-play"></span> Begin Tests
+                        </button>
+                      <% when 'error' %>
+                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
+                          <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
+                            <span class="oi oi-loop"></span> Rerun Skipped Tests
+                          </button>
+                        <% end %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-loop"></span> Rerun All Tests
+                        </button>
+                      <% when 'wait' %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-media-play"></span> Begin Tests
+                        </button>
+                      <% when 'skip' %>
+                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
+                          <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
+                            <span class="oi oi-loop"></span> Rerun Skipped Tests
+                          </button>
+                        <% end %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-loop"></span> Rerun All Tests
+                        </button>
+                      <% else %>
+                        <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
+                          <span class="oi oi-media-play"></span> Run
+                        </button>
                     <% end %>
 
                     <% if group_result.to_s != "not_run" %>
@@ -234,13 +228,22 @@
                         <button class="next next-back btn btn-info btn-sm" id=<%='cont-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
                           Next <span class="oi oi-media-step-forward"></span>
                         </button>
+                      <% else %>
+                        <button class="next placeholder btn btn-info btn-sm">
+                          Next <span class="oi oi-media-step-forward"></span>
+                        </button>
                       <% end %>
                       <% if index > 0 %>
                         <button class="back next-back btn btn-info btn-sm" id=<%='back-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index - 1)[:group].id%>>
                           <span class="oi oi-media-step-backward"></span> Back
                         </button>
+                      <% else %>
+                        <button class="back placeholder btn btn-info btn-sm">
+                          <span class="oi oi-media-step-backward"></span> Back
+                        </button>
                       <% end %>
                     <% end %>
+                  </div>
 
                   </div>
                   

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -229,6 +229,12 @@
                       </button>
                     <% end %>
                     
+                    <% if index < instance.group_results(test_set.id).length - 1 && group_result.to_s != "not_run" %>
+                      <button class="continue btn btn-info btn-sm" id='<%=group.id%>' data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
+                        <span class="oi oi-media-play"></span> Continue
+                      </button>
+                    <% end %>
+
                   </div>
                   
                 </div>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -228,11 +228,18 @@
                         <span class="oi oi-media-play"></span> Start
                       </button>
                     <% end %>
-                    
-                    <% if index < instance.group_results(test_set.id).length - 1 && group_result.to_s != "not_run" %>
-                      <button class="continue btn btn-info btn-sm" id='<%=group.id%>' data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
-                        <span class="oi oi-media-play"></span> Continue
-                      </button>
+
+                    <% if group_result.to_s != "not_run" %>
+                      <% if index < instance.group_results(test_set.id).length - 1 %>
+                        <button class="continue-back btn btn-info btn-sm" id=<%='cont-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
+                          <span class="oi oi-media-play"></span> Continue
+                        </button>
+                      <% end %>
+                      <% if index > 0 %>
+                        <button class="continue-back btn btn-info btn-sm" id=<%='back-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index - 1)[:group].id%>>
+                          <span class="oi oi-media-play"></span> Back
+                        </button>
+                      <% end %>
                     <% end %>
 
                   </div>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -176,11 +176,11 @@
                   </div>
                   <%= markdown_to_html(group.overview) %>
 
-                  <div class='buttons-container'>
+                  <div class='buttons-container buttons-container-<%=group_result.to_s%>'>
                     <% case group_result.to_s
                       when 'pass' %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                          <span class="oi oi-loop"></span> Rerun All Tests
+                          <span class="oi oi-loop"></span> Rerun Tests
                         </button>
                       <% when 'fail' %>
                         <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
@@ -189,7 +189,7 @@
                           </button>
                         <% end %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                          <span class="oi oi-loop"></span> Rerun All Tests
+                          <span class="oi oi-loop"></span> Rerun Tests
                         </button>
                       <% when 'cancel' %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
@@ -202,7 +202,7 @@
                           </button>
                         <% end %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                          <span class="oi oi-loop"></span> Rerun All Tests
+                          <span class="oi oi-loop"></span> Rerun Tests
                         </button>
                       <% when 'wait' %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
@@ -215,7 +215,7 @@
                           </button>
                         <% end %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                          <span class="oi oi-loop"></span> Rerun All Tests
+                          <span class="oi oi-loop"></span> Rerun Tests
                         </button>
                       <% else %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -183,7 +183,7 @@
                           <span class="oi oi-loop"></span> Rerun Tests
                         </button>
                       <% when 'fail' %>
-                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
+                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id]&.skip?} %>
                           <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
                             <span class="oi oi-loop"></span> Rerun Skipped Tests
                           </button>
@@ -196,7 +196,7 @@
                           <span class="oi oi-media-play"></span> Begin Tests
                         </button>
                       <% when 'error' %>
-                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
+                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id]&.skip?} %>
                           <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
                             <span class="oi oi-loop"></span> Rerun Skipped Tests
                           </button>
@@ -209,7 +209,7 @@
                           <span class="oi oi-media-play"></span> Begin Tests
                         </button>
                       <% when 'skip' %>
-                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
+                        <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id]&.skip?} %>
                           <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
                             <span class="oi oi-loop"></span> Rerun Skipped Tests
                           </button>
@@ -530,6 +530,7 @@
     </div>
   </div>
 </div>
+
 
 <div class="modal fade" data-backdrop="static" data-keyboard="false" id="testsRunningModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg" role="document">

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -165,7 +165,7 @@
                       </div>
                       <%= markdown_to_html(group.overview) %>
                       <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Rerun All Tests
+                        <span class="oi oi-loop"></span> Rerun All Tests
                       </button>
                     <% when 'fail' %>
                       <div class="group-message">
@@ -174,11 +174,11 @@
                       <%= markdown_to_html(group.overview) %>
                       <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
-                          <span class="oi oi-media-play"></span> Rerun Skipped Tests
+                          <span class="oi oi-loop"></span> Rerun Skipped Tests
                         </button>
                       <% end %>
                       <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Rerun All Tests
+                        <span class="oi oi-loop"></span> Rerun All Tests
                       </button>
                     <% when 'cancel' %>
                       <div class="group-message">
@@ -195,11 +195,11 @@
                       <%= markdown_to_html(group.overview) %>
                       <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
-                          <span class="oi oi-media-play"></span> Rerun Skipped Tests
+                          <span class="oi oi-loop"></span> Rerun Skipped Tests
                         </button>
                       <% end %>
                       <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Rerun All Tests
+                        <span class="oi oi-loop"></span> Rerun All Tests
                       </button>
                     <% when 'wait' %>
                       <div class="group-message">
@@ -216,28 +216,28 @@
                       <%= markdown_to_html(group.overview) %>
                       <% if group.run_skipped && group.test_cases.any?{ |test_case| sequence_results[test_case.id].try(:result) == 'skip'} %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>' data-skipped-only='true'>
-                          <span class="oi oi-media-play"></span> Rerun Skipped Tests
+                          <span class="oi oi-loop"></span> Rerun Skipped Tests
                         </button>
                       <% end %>
                       <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Rerun All Tests
+                        <span class="oi oi-loop"></span> Rerun All Tests
                       </button>
                     <% else %>
                       <%= markdown_to_html(group.overview) %>
                       <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                        <span class="oi oi-media-play"></span> Start
+                        <span class="oi oi-media-play"></span> Run
                       </button>
                     <% end %>
 
                     <% if group_result.to_s != "not_run" %>
                       <% if index < instance.group_results(test_set.id).length - 1 %>
-                        <button class="continue-back btn btn-info btn-sm" id=<%='cont-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
-                          <span class="oi oi-media-play"></span> Continue
+                        <button class="next next-back btn btn-info btn-sm" id=<%='cont-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
+                          Next <span class="oi oi-media-step-forward"></span>
                         </button>
                       <% end %>
                       <% if index > 0 %>
-                        <button class="continue-back btn btn-info btn-sm" id=<%='back-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index - 1)[:group].id%>>
-                          <span class="oi oi-media-play"></span> Back
+                        <button class="back next-back btn btn-info btn-sm" id=<%='back-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index - 1)[:group].id%>>
+                          <span class="oi oi-media-step-backward"></span> Back
                         </button>
                       <% end %>
                     <% end %>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -219,29 +219,28 @@
                         </button>
                       <% else %>
                         <button class='sequence-button btn btn-info btn-sm' data-group-id='<%=group.id%>'>
-                          <span class="oi oi-media-play"></span> Run
+                          <span class="oi oi-media-play"></span> Run Tests
                         </button>
                     <% end %>
 
-                    <% if group_result.to_s != "not_run" %>
-                      <% if index < instance.group_results(test_set.id).length - 1 %>
-                        <button class="next next-back btn btn-info btn-sm" id=<%='cont-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
-                          Next <span class="oi oi-media-step-forward"></span>
-                        </button>
-                      <% else %>
-                        <button class="next placeholder btn btn-info btn-sm">
-                          Next <span class="oi oi-media-step-forward"></span>
-                        </button>
-                      <% end %>
-                      <% if index > 0 %>
-                        <button class="back next-back btn btn-info btn-sm" id=<%='back-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index - 1)[:group].id%>>
-                          <span class="oi oi-media-step-backward"></span> Back
-                        </button>
-                      <% else %>
-                        <button class="back placeholder btn btn-info btn-sm">
-                          <span class="oi oi-media-step-backward"></span> Back
-                        </button>
-                      <% end %>
+                    <% if index < instance.group_results(test_set.id).length - 1 && group_result.to_s != "not_run" %>
+                      <button class="next next-back btn btn-info btn-sm" id=<%='cont-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index + 1)[:group].id%>>
+                        Next <span class="oi oi-media-step-forward"></span>
+                      </button>
+                    <% else %>
+                      <button class="next placeholder btn btn-info btn-sm">
+                        Next <span class="oi oi-media-step-forward"></span>
+                      </button>
+                    <% end %>
+                    
+                    <% if index > 0 %>
+                      <button class="back next-back btn btn-info btn-sm" id=<%='back-'+group.id%> data-next_tab=<%=instance.group_results(test_set.id).at(index - 1)[:group].id%>>
+                        <span class="oi oi-media-step-backward"></span> Back
+                      </button>
+                    <% else %>
+                      <button class="back placeholder btn btn-info btn-sm">
+                        <span class="oi oi-media-step-backward"></span> Back
+                      </button>
                     <% end %>
                   </div>
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1097,7 +1097,7 @@ body {
   margin-right: 10px;
 }
 
-.guided .continue {
+.guided .continue-back {
   cursor:pointer; 
   font-size: 1.2rem;
   margin-bottom: 1rem;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1090,6 +1090,7 @@ body {
   margin-bottom: 1rem;
   margin-right: 10px;
 }
+
 .guided .sequence-button-next {
   cursor:pointer; 
   font-size: 1.2rem;
@@ -1097,12 +1098,22 @@ body {
   margin-right: 10px;
 }
 
-.guided .continue-back {
+.guided .next-back {
   cursor:pointer; 
+  background-color: #7b9ba0;
+  border-color: #7b9ba0;
   font-size: 1.2rem;
   margin-bottom: 1rem;
   margin-right: 10px;
   float: right;
+}
+
+.guided .oi-media-step-forward {
+  font-size: 1rem;
+}
+
+.guided .oi-media-step-backward {
+  font-size: 1rem;
 }
 
 .guided span.oi.oi-warning.prerequisite-tooltip {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1116,6 +1116,15 @@ body {
   text-align: center;
 }
 
+.guided .buttons-container-pass .next{
+  background-color: #17a2b8;
+}
+
+.guided .buttons-container-pass .sequence-button{
+  background-color: #7b9ba0;
+}
+
+
 .guided .next {
   float: right;
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1104,8 +1104,24 @@ body {
   border-color: #7b9ba0;
   font-size: 1.2rem;
   margin-bottom: 1rem;
-  margin-right: 10px;
+}
+
+.guided .placeholder {
+  visibility: hidden;
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.guided .buttons-container {
+  text-align: center;
+}
+
+.guided .next {
   float: right;
+}
+
+.guided .back {
+  float: left;
 }
 
 .guided .oi-media-step-forward {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1097,6 +1097,14 @@ body {
   margin-right: 10px;
 }
 
+.guided .continue {
+  cursor:pointer; 
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+  margin-right: 10px;
+  float: right;
+}
+
 .guided span.oi.oi-warning.prerequisite-tooltip {
   display: none;
   width: 0;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -365,7 +365,7 @@ $(function(){
     }
   });
 
-  $(document.getElementsByClassName("continue")).on('click', function() {
+  $(document.getElementsByClassName("continue-back")).on('click', function() {
     var next_tab = $('#' + this.id).data('next_tab');
     $('#group-link-' + next_tab).click();
   });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -365,7 +365,7 @@ $(function(){
     }
   });
 
-  $(document.getElementsByClassName("continue-back")).on('click', function() {
+  $(document.getElementsByClassName("next-back")).on('click', function() {
     var next_tab = $('#' + this.id).data('next_tab');
     $('#group-link-' + next_tab).click();
   });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -364,4 +364,9 @@ $(function(){
       document.getElementById("instructions-link").style.display = "none";
     }
   });
+
+  $(document.getElementsByClassName("continue")).on('click', function() {
+    var next_tab = $('#' + this.id).data('next_tab');
+    $('#group-link-' + next_tab).click();
+  });
 }); 


### PR DESCRIPTION
Added a "Continue" and "Back" button to the guided tests. The buttons appear after the test is run, no matter the result. The buttons have the same functionality as clicking the tabs at the top. 

<img width="940" alt="Screen Shot 2019-06-17 at 2 12 34 PM" src="https://user-images.githubusercontent.com/47094547/59626485-fd2f9d00-9109-11e9-870e-25e21545b156.png">