### PR TITLE
Fix report rollup

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -260,7 +260,7 @@ module Inferno
             supported_resources: instance.supported_resources.count,
             request_response: request_response_count,
             latest_sequence_time: latest_sequence_time,
-            final_result: instance.final_result,
+            final_result: instance.final_result(params[:test_set]),
             inferno_url: "#{request.base_url}#{base_path}/#{instance.id}/#{params[:test_set]}/"
           }
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -98,7 +98,7 @@ module Inferno
       end
 
       def all_test_cases(test_set_id)
-        self.module.test_sets[test_set_id.to_sym].groups.each_with_object([]) { |g, o| o.push(*g.test_cases) }
+        self.module.test_sets[test_set_id.to_sym].groups.flat_map(&:test_cases)
       end
 
       def all_passed?(test_set_id)

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -2,6 +2,7 @@
 
 require 'dm-core'
 require 'dm-migrations'
+require_relative '../utils/result_statuses'
 
 module Inferno
   module Models
@@ -119,9 +120,9 @@ module Inferno
 
       def final_result(test_set_id)
         if all_passed?(test_set_id)
-          'pass'
+          Inferno::ResultStatuses::PASS
         else
-          any_failed?(test_set_id) ? 'fail' : 'incomplete'
+          any_failed?(test_set_id) ? Inferno::ResultStatuses::FAIL : Inferno::ResultStatuses::PENDING
         end
       end
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -113,7 +113,7 @@ module Inferno
         latest_results = latest_results_by_case
 
         all_test_cases(test_set_id).any? do |test_case|
-         latest_results[test_case.id]&.fail?
+          latest_results[test_case.id]&.fail?
         end
       end
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -105,7 +105,7 @@ module Inferno
         latest_results = latest_results_by_case
 
         all_test_cases(test_set_id).all? do |test_case|
-          latest_results[test_case.id]&.result == 'pass'
+          latest_results[test_case.id]&.pass?
         end
       end
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -113,7 +113,7 @@ module Inferno
         latest_results = latest_results_by_case
 
         all_test_cases(test_set_id).any? do |test_case|
-          ['fail', 'error'].include? latest_results[test_case.id]&.result
+         latest_results[test_case.id]&.fail?
         end
       end
 

--- a/lib/app/utils/result_statuses.rb
+++ b/lib/app/utils/result_statuses.rb
@@ -8,8 +8,9 @@ module Inferno
     SKIP = 'skip'
     WAIT = 'wait'
     TODO = 'todo'
+    PENDING = 'pending'
 
-    STATUS_LIST = [FAIL, ERROR, PASS, SKIP, WAIT, TODO].freeze
+    STATUS_LIST = [FAIL, ERROR, PASS, SKIP, WAIT, TODO, PENDING].freeze
 
     def fail?
       result == FAIL || error?
@@ -35,6 +36,10 @@ module Inferno
       result == TODO
     end
 
+    def pending?
+      result == PENDING
+    end
+
     def fail!
       self.result = FAIL
     end
@@ -57,6 +62,10 @@ module Inferno
 
     def todo!
       self.result = TODO
+    end
+
+    def pending!
+      self.result = PENDING
     end
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Inferno
-  VERSION = '2.3.0-pre1'
+  VERSION = '2.3.0-pre2'
 end

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1195,9 +1195,10 @@ body {
 }
 
 .metrics-value{
-  font-size: 5em;
-  margin-bottom: -30px;
+  font-size: 2.3em;
   text-transform: uppercase;
+  line-height: 1.1em;
+  margin-top: 40px;
 }
 
 .metrics-value-small{
@@ -1208,10 +1209,6 @@ body {
 .report-summary{
   margin: 10px 0;
   padding: 8px 0;
-}
-
-.result-column{
-  padding-left:50px;
 }
 
 .report-summary .col{

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1195,7 +1195,7 @@ body {
 }
 
 .metrics-value{
-  font-size: 2.3em;
+  font-size: 2.5em;
   text-transform: uppercase;
   line-height: 1.1em;
   margin-top: 40px;


### PR DESCRIPTION
The rollup report didn't work properly because it required all sequences stored in inferno to have been passed.  Since we added the concept of modules and test_sets, this doesn't work anymore.  Updated to use the new test structures.

Also, before it would mark as 'fail', even if you hadn't run any tests yet.  Updated to mark as 'incomplete' if you hadn't passed everything but haven't failed anything either.

<img width="766" alt="Screen Shot 2019-06-24 at 9 50 58 PM" src="https://user-images.githubusercontent.com/412901/60063746-f7b6f180-96cb-11e9-8d54-5636bb834ef9.png">

