### PR TITLE
Fix DSTU2 CareTeam profile validation

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -129,7 +129,7 @@ module Inferno
 
               out << js_hide_wait_modal
               out << js_show_test_modal
-              count = sequence_result.test_results.length
+              count = sequence_result.result_count
 
               submitted_test_cases_count = sequence_result.next_test_cases.split(',')
               total_tests = submitted_test_cases_count.reduce(first_test_count) do |total, set|
@@ -361,7 +361,7 @@ module Inferno
             x.sequence_name == sequence_result.name
           end
 
-          current_test_count = sequence_result.test_results.length
+          current_test_count = sequence_result.result_count
 
           sequence.tests.each_with_index do |test, index|
             next if index < current_test_count

--- a/lib/app/models/resource_reference.rb
+++ b/lib/app/models/resource_reference.rb
@@ -7,6 +7,7 @@ module Inferno
       property :id, String, key: true, default: proc { SecureRandom.uuid }
       property :resource_type, String
       property :resource_id, String
+      property :profile, String
 
       belongs_to :testing_instance
     end

--- a/lib/app/models/sequence_result.rb
+++ b/lib/app/models/sequence_result.rb
@@ -52,6 +52,46 @@ module Inferno
           'optional_total'
         ].each { |field| send("#{field}=", 0) }
       end
+
+      def result_count
+        test_results.length
+      end
+
+      def update_result_counts
+        test_results.each do |result|
+          if result.required
+            self.required_total += 1
+          else
+            self.optional_total += 1
+          end
+          case result.result
+          when ResultStatuses::PASS
+            if result.required
+              self.required_passed += 1
+            else
+              self.optional_passed += 1
+            end
+          when ResultStatuses::TODO
+            self.todo_count += 1
+          when ResultStatuses::FAIL
+            if result.required
+              self.result = result.result unless error?
+            end
+          when ResultStatuses::ERROR
+            if result.required
+              self.error_count += 1
+              self.result = result.result
+            end
+          when ResultStatuses::SKIP
+            if result.required
+              self.skip_count += 1
+              self.result = result.result if pass?
+            end
+          when ResultStatuses::WAIT
+            self.result = result.result
+          end
+        end
+      end
     end
   end
 end

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -225,12 +225,16 @@ module Inferno
         end
       end
 
-      def save_resource_reference(type, id)
+      def save_resource_reference(type, id, profile = nil)
         resource_references
           .select { |ref| (ref.resource_type == type) && (ref.resource_id == id) }
           .each(&:destroy)
 
-        new_reference = ResourceReference.new(resource_type: type, resource_id: id)
+        new_reference = ResourceReference.new(
+          resource_type: type,
+          resource_id: id,
+          profile: profile
+        )
         resource_references << new_reference
 
         save!
@@ -238,13 +242,13 @@ module Inferno
         reload
       end
 
-      def save_resource_ids_in_bundle(klass, reply)
+      def save_resource_ids_in_bundle(klass, reply, profile = nil)
         return if reply&.resource&.entry&.blank?
 
         reply.resource.entry
           .select { |entry| entry.resource.class == klass }
           .each do |entry|
-          save_resource_reference(klass.name.demodulize, entry.resource.id)
+          save_resource_reference(klass.name.demodulize, entry.resource.id, profile)
         end
       end
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -238,6 +238,16 @@ module Inferno
         reload
       end
 
+      def save_resource_ids_in_bundle(klass, reply)
+        return if reply&.resource&.entry&.blank?
+
+        reply.resource.entry
+          .select { |entry| entry.resource.class == klass }
+          .each do |entry|
+          save_resource_reference(klass.name.demodulize, entry.resource.id)
+        end
+      end
+
       def versioned_conformance_class
         if fhir_version == 'dstu2'
           FHIR::DSTU2::Conformance

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -236,6 +236,16 @@ module Inferno
         reload
       end
 
+      def versioned_conformance_class
+        if fhir_version == 'dstu2'
+          FHIR::DSTU2::Conformance
+        elsif fhir_version == 'stu3'
+          FHIR::STU3::CapabilityStatement
+        else
+          FHIR::CapabilityStatement
+        end
+      end
+
       private
 
       def interaction_supported?(capabilities, interaction_code)

--- a/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careplan_sequence.rb
@@ -3,6 +3,8 @@
 module Inferno
   module Sequence
     class ArgonautCarePlanSequence < SequenceBase
+      PROFILE = Inferno::ValidationUtil::ARGONAUT_URIS[:care_plan]
+
       group 'Argonaut Profile Conformance'
 
       title 'Care Plan'
@@ -102,7 +104,7 @@ module Inferno
 
         @careplan = reply.try(:resource).try(:entry).try(:first).try(:resource)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
-        save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply, PROFILE)
       end
 
       test 'Server returns expected results from CarePlan search by patient + category + date' do
@@ -228,9 +230,9 @@ module Inferno
           )
           versions :dstu2
         end
-        test_resources_against_profile('CarePlan', Inferno::ValidationUtil::ARGONAUT_URIS[:care_plan])
-        skip_unless @profiles_encountered.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:care_plan]), 'No CarePlans found.'
-        assert !@profiles_failed.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:care_plan]), "CarePlans failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:care_plan]]}"
+        test_resources_against_profile('CarePlan', PROFILE)
+        skip_unless @profiles_encountered.include?(PROFILE), 'No CarePlans found.'
+        assert !@profiles_failed.include?(PROFILE), "CarePlans failed validation.<br/>#{@profiles_failed[PROFILE]}"
       end
 
       test 'All references can be resolved' do

--- a/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_careteam_sequence.rb
@@ -3,6 +3,8 @@
 module Inferno
   module Sequence
     class ArgonautCareTeamSequence < SequenceBase
+      PROFILE = Inferno::ValidationUtil::ARGONAUT_URIS[:care_team]
+
       group 'Argonaut Profile Conformance'
 
       title 'Care Team'
@@ -73,10 +75,10 @@ module Inferno
         resource_count = reply.try(:resource).try(:entry).try(:length) || 0
         @resources_found = resource_count.positive?
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip_unless @resources_found, 'No resources appear to be available for this patient. Please use patients with more information.'
         @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
-        save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply, PROFILE)
       end
 
       test 'CareTeam resources associated with Patient conform to Argonaut profiles' do
@@ -88,9 +90,9 @@ module Inferno
           )
           versions :dstu2
         end
-        test_resources_against_profile('CarePlan', Inferno::ValidationUtil::ARGONAUT_URIS[:care_team])
-        skip_unless @profiles_encountered.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:care_team]), 'No CareTeams found.'
-        assert !@profiles_failed.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:care_team]), "CareTeams failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:care_team]]}"
+        test_resources_against_profile('CarePlan', PROFILE)
+        skip_unless @profiles_encountered.include?(PROFILE), 'No CareTeams found.'
+        assert !@profiles_failed.include?(PROFILE), "CareTeams failed validation.<br/>#{@profiles_failed[PROFILE]}"
       end
 
       test 'All references can be resolved' do

--- a/lib/app/modules/argonaut/argonaut_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_observation_sequence.rb
@@ -3,6 +3,9 @@
 module Inferno
   module Sequence
     class ArgonautObservationSequence < SequenceBase
+      SMOKING_STATUS_PROFILE = Inferno::ValidationUtil::ARGONAUT_URIS[:smoking_status]
+      OBSERVATION_RESULTS_PROFILE = Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results]
+
       title 'Observation'
 
       description 'Verify that Observation resources on the FHIR server follow the Argonaut Data Query Implementation Guide'
@@ -92,7 +95,7 @@ module Inferno
 
         @observationresults = reply.try(:resource).try(:entry).try(:first).try(:resource)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, OBSERVATION_RESULTS_PROFILE)
       end
 
       test 'Server returns expected results from Observation Results search by patient + category + date' do
@@ -198,7 +201,7 @@ module Inferno
         search_params = { patient: @instance.patient_id, code: '72166-2' }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, SMOKING_STATUS_PROFILE)
       end
 
       test 'Observation read resource supported' do
@@ -261,9 +264,9 @@ module Inferno
           versions :dstu2
         end
 
-        test_resources_against_profile('Observation', Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results])
-        skip_unless @profiles_encountered.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results]), 'No Observation Results found.'
-        assert !@profiles_failed.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results]), "Observation Results failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results]]}"
+        test_resources_against_profile('Observation', OBSERVATION_RESULTS_PROFILE)
+        skip_unless @profiles_encountered.include?(OBSERVATION_RESULTS_PROFILE), 'No Observation Results found.'
+        assert !@profiles_failed.include?(OBSERVATION_RESULTS_PROFILE), "Observation Results failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results]]}"
       end
 
       test 'All references can be resolved' do

--- a/lib/app/modules/argonaut/argonaut_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_observation_sequence.rb
@@ -266,7 +266,7 @@ module Inferno
 
         test_resources_against_profile('Observation', OBSERVATION_RESULTS_PROFILE)
         skip_unless @profiles_encountered.include?(OBSERVATION_RESULTS_PROFILE), 'No Observation Results found.'
-        assert !@profiles_failed.include?(OBSERVATION_RESULTS_PROFILE), "Observation Results failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:observation_results]]}"
+        assert !@profiles_failed.include?(OBSERVATION_RESULTS_PROFILE), "Observation Results failed validation.<br/>#{@profiles_failed[OBSERVATION_RESULTS_PROFILE]}"
       end
 
       test 'All references can be resolved' do

--- a/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_smoking_status_sequence.rb
@@ -3,6 +3,8 @@
 module Inferno
   module Sequence
     class ArgonautSmokingStatusSequence < SequenceBase
+      PROFILE = Inferno::ValidationUtil::ARGONAUT_URIS[:smoking_status]
+
       group 'Argonaut Profile Conformance'
 
       title 'Smoking Status'
@@ -84,7 +86,7 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, PROFILE)
       end
 
       test 'Smoking Status resources associated with Patient conform to Argonaut profiles' do
@@ -96,9 +98,9 @@ module Inferno
           )
           versions :dstu2
         end
-        test_resources_against_profile('Observation', Inferno::ValidationUtil::ARGONAUT_URIS[:smoking_status])
-        skip_unless @profiles_encountered.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:smoking_status]), 'No Smoking Status Observations found.'
-        assert !@profiles_failed.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:smoking_status]), "Smoking Status Observations failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:smoking_status]]}"
+        test_resources_against_profile('Observation', PROFILE)
+        skip_unless @profiles_encountered.include?(PROFILE), 'No Smoking Status Observations found.'
+        assert !@profiles_failed.include?(PROFILE), "Smoking Status Observations failed validation.<br/>#{@profiles_failed[PROFILE]}"
       end
     end
   end

--- a/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_vital_signs_observation_sequence.rb
@@ -3,6 +3,8 @@
 module Inferno
   module Sequence
     class ArgonautVitalSignsSequence < SequenceBase
+      PROFILE = Inferno::ValidationUtil::ARGONAUT_URIS[:vital_signs]
+
       title 'Vital Signs'
 
       description 'Verify that Vital Signs are collected on the FHIR server according to the Argonaut Data Query Implementation Guide'
@@ -92,7 +94,7 @@ module Inferno
 
         @vitalsigns = reply.try(:resource).try(:entry).try(:first).try(:resource)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
+        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, PROFILE)
       end
 
       test 'Server returns expected results from Vital Signs search by patient + category + date' do
@@ -170,9 +172,9 @@ module Inferno
           versions :dstu2
         end
 
-        test_resources_against_profile('Observation', Inferno::ValidationUtil::ARGONAUT_URIS[:vital_signs])
-        skip_unless @profiles_encountered.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:vital_signs]), 'No Vital Sign Observations found.'
-        assert !@profiles_failed.include?(Inferno::ValidationUtil::ARGONAUT_URIS[:vital_signs]), "Vital Sign Observations failed validation.<br/>#{@profiles_failed[Inferno::ValidationUtil::ARGONAUT_URIS[:vital_signs]]}"
+        test_resources_against_profile('Observation', PROFILE)
+        skip_unless @profiles_encountered.include?(PROFILE), 'No Vital Sign Observations found.'
+        assert !@profiles_failed.include?(PROFILE), "Vital Sign Observations failed validation.<br/>#{@profiles_failed[PROFILE]}"
       end
     end
   end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -44,6 +44,7 @@ module Inferno
 
       delegate :versioned_resource_class, to: :@client
       delegate :versioned_conformance_class, to: :@instance
+      delegate :save_resource_ids_in_bundle, to: :@instance
 
       def initialize(instance, client, disable_tls_tests = false, sequence_result = nil, metadata_only = false)
         @client = client
@@ -552,16 +553,6 @@ module Inferno
             validate_resource_item(entry.resource, key.to_s, value)
           end
         end
-      end
-
-      def save_resource_ids_in_bundle(klass, reply)
-        return if reply&.resource&.entry&.blank?
-
-        reply.resource.entry
-          .select { |entry| entry.resource.class == klass }
-          .each do |entry|
-            @instance.save_resource_reference(klass.name.demodulize, entry.resource.id)
-          end
       end
 
       def validate_read_reply(resource, klass)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -9,6 +9,7 @@ require_relative 'utils/validation'
 require_relative 'utils/walk'
 require_relative 'utils/web_driver'
 require_relative 'utils/terminology'
+require_relative 'utils/result_statuses'
 
 require 'bloomer'
 require 'bloomer/msgpackable'
@@ -22,8 +23,6 @@ module Inferno
       include Assertions
       include SkipHelpers
       include Inferno::WebDriver
-
-      STATUS = { pass: 'pass', fail: 'fail', error: 'error', todo: 'todo', wait: 'wait', skip: 'skip' }.freeze
 
       @@test_index = 0
 
@@ -43,6 +42,9 @@ module Inferno
 
       @@test_id_prefixes = {}
 
+      delegate :versioned_resource_class, to: :@client
+      delegate :versioned_conformance_class, to: :@instance
+
       def initialize(instance, client, disable_tls_tests = false, sequence_result = nil, metadata_only = false)
         @client = client
         @instance = instance
@@ -60,7 +62,7 @@ module Inferno
         @sequence_result.test_results.last.pass!
 
         if fail_message.present?
-          @sequence_result.test_results.last.result = STATUS[:fail]
+          @sequence_result.test_results.last.fail!
           @sequence_result.test_results.last.message = fail_message
         end
 
@@ -88,7 +90,7 @@ module Inferno
         if @sequence_result.nil?
           @sequence_result = Models::SequenceResult.new(
             name: sequence_name,
-            result: STATUS[:pass],
+            result: ResultStatuses::PASS,
             testing_instance: @instance,
             required: !optional?,
             test_set_id: test_set_id,
@@ -98,7 +100,7 @@ module Inferno
           @sequence_result.save!
         end
 
-        start_at = @sequence_result.test_results.length
+        start_at = @sequence_result.result_count
 
         load_input_params(sequence_name)
 
@@ -109,14 +111,15 @@ module Inferno
         run_tests(methods, &block)
 
         update_output(sequence_name, output_results)
-        @sequence_result.output_results = output_results.to_json if output_results.present?
 
-        @sequence_result.reset!
-        @sequence_result.pass!
+        @sequence_result.tap do |result|
+          result.output_results = output_results.to_json if output_results.present?
 
-        update_result_counts
+          result.reset!
+          result.pass!
 
-        @sequence_result
+          result.update_result_counts
+        end
       end
 
       def load_input_params(sequence_name)
@@ -199,42 +202,6 @@ module Inferno
         end
       end
 
-      def update_result_counts
-        @sequence_result.test_results.each do |result|
-          if result.required
-            @sequence_result.required_total += 1
-          else
-            @sequence_result.optional_total += 1
-          end
-          case result.result
-          when STATUS[:pass]
-            if result.required
-              @sequence_result.required_passed += 1
-            else
-              @sequence_result.optional_passed += 1
-            end
-          when STATUS[:todo]
-            @sequence_result.todo_count += 1
-          when STATUS[:fail]
-            if result.required
-              @sequence_result.result = result.result unless @sequence_result.error?
-            end
-          when STATUS[:error]
-            if result.required
-              @sequence_result.error_count += 1
-              @sequence_result.result = result.result
-            end
-          when STATUS[:skip]
-            if result.required
-              @sequence_result.skip_count += 1
-              @sequence_result.result = result.result if @sequence_result.pass?
-            end
-          when STATUS[:wait]
-            @sequence_result.result = result.result
-          end
-        end
-      end
-
       def self.test_count
         new(nil, nil).test_count
       end
@@ -255,8 +222,6 @@ module Inferno
       def self.sequence_name
         name.demodulize
       end
-
-      attr_reader :sequence_result
 
       def self.title(title = nil)
         @@titles[sequence_name] = title unless title.nil?
@@ -413,7 +378,7 @@ module Inferno
             description: current_test[:description],
             url: current_test[:url],
             versions: versions.join(','),
-            result: STATUS[:pass],
+            result: ResultStatuses::PASS,
             test_index: test_index
           )
           begin
@@ -539,12 +504,8 @@ module Inferno
         @client.search(klass, options)
       end
 
-      def versioned_resource_class(klass)
-        @client.versioned_resource_class klass
-      end
-
-      def check_sort_order(entries)
-        relevant_entries = entries.reject { |x| x.request.try(:local_method) == 'DELETE' }
+      def validate_sort_order(entries)
+        relevant_entries = entries.reject { |entry| entry.request&.local_method == 'DELETE' }
         begin
           relevant_entries.map!(&:resource).map!(&:meta).compact
         rescue StandardError
@@ -552,13 +513,16 @@ module Inferno
         end
 
         relevant_entries.each_cons(2) do |left, right|
-          if !left.versionId.nil? && !right.versionId.nil?
-            assert (left.versionId > right.versionId), 'Result contains entries in the wrong order.'
-          elsif !left.lastUpdated.nil? && !right.lastUpdated.nil?
-            assert (left.lastUpdated >= right.lastUpdated), 'Result contains entries in the wrong order.'
-          else
-            raise AssertionException, 'Unable to determine if entries are in the correct order -- no meta.versionId or meta.lastUpdated'
-          end
+          left_version, right_version =
+            if left.versionId.present? && right.versionId.present?
+              [left.versionId, right.versionId]
+            elsif left.lastUpdated.present? && right.lastUpdated.present?
+              [left.lastUpdated, right.lastUpdated]
+            else
+              raise AssertionException, 'Unable to determine if entries are in the correct order -- no meta.versionId or meta.lastUpdated'
+            end
+
+          assert (left_version > right_version), 'Result contains entries in the wrong order.'
         end
       end
 
@@ -571,10 +535,10 @@ module Inferno
         assert_bundle_response(reply)
 
         entries = reply.resource.entry.select { |entry| entry.resource.class == klass }
-        assert !entries.empty?, 'No resources of this type were returned'
+        assert entries.present?, 'No resources of this type were returned'
 
         if klass == versioned_resource_class('Patient')
-          assert !reply.resource.get_by_id(@instance.patient_id).nil?, 'Server returned nil patient'
+          assert reply.resource.get_by_id(@instance.patient_id).present?, 'Server returned nil patient'
           assert reply.resource.get_by_id(@instance.patient_id).equals?(@patient, ['_id', 'text', 'meta', 'lastUpdated']), 'Server returned wrong patient'
         end
 
@@ -591,18 +555,18 @@ module Inferno
       end
 
       def save_resource_ids_in_bundle(klass, reply)
-        return if reply.try(:resource).try(:entry).nil?
+        return if reply&.resource&.entry.blank?
 
         entries = reply.resource.entry.select { |entry| entry.resource.class == klass }
 
         entries.each do |entry|
-          @instance.post_resource_references(resource_type: klass.name.split(':').last,
+          @instance.post_resource_references(resource_type: klass.name.demodulize,
                                              resource_id: entry.resource.id)
         end
       end
 
       def validate_read_reply(resource, klass)
-        assert !resource.nil?, "No #{klass.name.split(':').last} resources available from search."
+        assert !resource.nil?, "No #{klass.name.demodulize} resources available from search."
         if resource.is_a? FHIR::DSTU2::Reference
           read_response = resource.read
         else
@@ -617,7 +581,7 @@ module Inferno
       end
 
       def validate_history_reply(resource, klass)
-        assert !resource.nil?, "No #{klass.name.split(':').last} resources available from search."
+        assert !resource.nil?, "No #{klass.name.demodulize} resources available from search."
         id = resource.try(:id)
         assert !id.nil?, "#{klass} id not returned"
         history_response = @client.resource_instance_history(klass, id)
@@ -627,11 +591,11 @@ module Inferno
         entries = history_response.try(:resource).try(:entry)
         assert entries, 'No bundle entries returned'
         assert entries.try(:length).positive?, 'No resources of this type were returned'
-        check_sort_order entries
+        validate_sort_order entries
       end
 
       def validate_vread_reply(resource, klass)
-        assert !resource.nil?, "No #{klass.name.split(':').last} resources available from search."
+        assert !resource.nil?, "No #{klass.name.demodulize} resources available from search."
         id = resource.try(:id)
         assert !id.nil?, "#{klass} id not returned"
         version_id = resource.try(:meta).try(:versionId)
@@ -710,16 +674,6 @@ module Inferno
         end
 
         assert(problems.empty?, problems.join("<br/>\n"))
-      end
-
-      def versioned_conformance_class
-        if @instance.fhir_version == 'dstu2'
-          FHIR::DSTU2::Conformance
-        elsif @instance.fhir_version == 'stu3'
-          FHIR::STU3::CapabilityStatement
-        else
-          FHIR::CapabilityStatement
-        end
       end
 
       def check_resource_against_profile(resource, resource_type, specified_profile = nil)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -555,14 +555,13 @@ module Inferno
       end
 
       def save_resource_ids_in_bundle(klass, reply)
-        return if reply&.resource&.entry.blank?
+        return if reply&.resource&.entry&.blank?
 
-        entries = reply.resource.entry.select { |entry| entry.resource.class == klass }
-
-        entries.each do |entry|
-          @instance.post_resource_references(resource_type: klass.name.demodulize,
-                                             resource_id: entry.resource.id)
-        end
+        reply.resource.entry
+          .select { |entry| entry.resource.class == klass }
+          .each do |entry|
+            @instance.save_resource_reference(klass.name.demodulize, entry.resource.id)
+          end
       end
 
       def validate_read_reply(resource, klass)

--- a/test/unit/argonaut_fixture_test.rb
+++ b/test/unit/argonaut_fixture_test.rb
@@ -22,8 +22,8 @@ class ArgonautFixtureTest < MiniTest::Test
     errors = []
     @invalid.entry.each do |entry|
       profile = Inferno::ValidationUtil.guess_profile(entry.resource, :dstu2)
-      errors += profile.validate_resource(entry.resource) unless profile.nil?
+      errors += profile.validate_resource(entry.resource) if profile.present?
     end
-    assert !errors.empty?, 'Expected numerous validation errors.'
+    assert errors.present?, 'Expected numerous validation errors.'
   end
 end


### PR DESCRIPTION
This branch modifies how resources are validated against a profile. Previously, passing a profile to `SequenceBase#test_resources_against_profile` didn't guarantee that the resources were actually validated against the specified profile. Now, when it receives a specific profile, it:

- Validates any resources which were saved and categorized as conforming to that profile
- If no resources have been saved with that profile, it checks `meta.profile` for resources which claim to conform to the profile and validates those
- If no resources were found, the test is skipped

I did a fair amount of refactoring while investigating this problem, so the actual bug fix is all in [this commit.](https://github.com/siteadmin/inferno/pull/224/commits/3fb4ba8383d8b8e2c77133512ca5a0433b46898a)

**NOTE:** the `sequence_base.rb` diff is collapsed by default, so be sure to expand it