### PR TITLE
Patient ID not saving when input from a user (eg. US Core R4).

### DIFF
--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -152,6 +152,8 @@ module Inferno
           resource_id: patient_id
         )
 
+        save!
+
         reload
       end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Inferno
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/test/model/testing_instance_test.rb
+++ b/test/model/testing_instance_test.rb
@@ -5,8 +5,8 @@ require_relative '../../lib/app/models/testing_instance'
 
 class TestingInstanceTest < MiniTest::Test
   def setup
-    @patient_id1 = 1
-    @patient_id2 = 2
+    @patient_id1 = '1'
+    @patient_id2 = '2'
     @testing_instance = Inferno::Models::TestingInstance.new
     @testing_instance.resource_references << Inferno::Models::ResourceReference.new(
       resource_type: 'Patient',
@@ -20,7 +20,9 @@ class TestingInstanceTest < MiniTest::Test
 
     @testing_instance.patient_id = @patient_id2
 
-    assert(@testing_instance.resource_references.empty?)
+    assert(@testing_instance.patient_id == @patient_id2)
+    assert(@testing_instance.resource_references.length == 1)
+    assert(@testing_instance.resource_references.first.resource_id == @patient_id2)
   end
 
   def test_patient_id_reassignment


### PR DESCRIPTION
See #235 

Somehow DataMapper isn't saving the patient_id when input by the user.  To replicate, run US Core R4 tests, run the Allergy Intolerance Sequence, enter any Bearer Token and Patient ID, and not that the patient_id is never persisted to the db and therefore isn't picked up by our tests.

Creating a hotfix and new patch version because this is a critical bug. We can merge back into development afterwards.