### PR TITLE
Fi 258 fail on launches if no auth

### DIFF
--- a/lib/app/modules/smart/smart_discovery_sequence.rb
+++ b/lib/app/modules/smart/smart_discovery_sequence.rb
@@ -84,9 +84,9 @@ module Inferno
         @conformance_authorize_url = oauth_metadata[:authorize_url]
         @conformance_token_url = oauth_metadata[:token_url]
         assert !@conformance_authorize_url.blank?, 'No authorize URI provided in Conformance/CapabilityStatement resource'
-        assert (@conformance_authorize_url =~ /\A#{URI.regexp(['http', 'https'])}\z/).zero?, "Invalid authorize url: '#{@conformance_authorize_url}'"
+        assert_valid_http_uri @conformance_authorize_url, "Invalid authorize url: '#{@conformance_authorize_url}'"
         assert !@conformance_token_url.blank?, 'No token URI provided in conformance statement.'
-        assert (@conformance_token_url =~ /\A#{URI.regexp(['http', 'https'])}\z/).zero?, "Invalid token url: '#{@conformance_token_url}'"
+        assert_valid_http_uri @conformance_token_url, "Invalid token url: '#{@conformance_token_url}'"
 
         warning do
           service = []
@@ -109,7 +109,7 @@ module Inferno
           registration_url = security_info.extension.find { |x| x.url == 'register' }
           registration_url = registration_url.value if registration_url
           assert !registration_url.blank?, 'No dynamic registration endpoint in conformance.'
-          assert (registration_url =~ /\A#{URI.regexp(['http', 'https'])}\z/).zero?, "Invalid registration url: '#{registration_url}'"
+          assert_valid_http_uri registration_url, "Invalid registration url: '#{registration_url}'"
 
           manage_url = security_info.extension.find { |x| x.url == 'manage' }
           manage_url = manage_url.value if manage_url

--- a/lib/app/modules/smart/standalone_launch_sequence.rb
+++ b/lib/app/modules/smart/standalone_launch_sequence.rb
@@ -35,8 +35,8 @@ module Inferno
         !@instance.client_id.nil?
       end
 
-      OAUTH_REDIRECT_FAILED = "Redirect to OAuth server failed"
-      NO_TOKEN = "No valid token"
+      OAUTH_REDIRECT_FAILED = 'Redirect to OAuth server failed'
+      NO_TOKEN = 'No valid token'
 
       test 'OAuth 2.0 authorize endpoint secured by transport layer security' do
         metadata do
@@ -75,7 +75,6 @@ module Inferno
           'aud' => @instance.url
         }
 
-
         oauth_authorize_endpoint = @instance.oauth_authorize_endpoint
 
         # Confirm that oauth2_auth_endpoint is valid before moving forward
@@ -105,8 +104,8 @@ module Inferno
           )
         end
 
-        # Confirm that there is a @params object from the redirect 
-        assert !@params.nil?, OAUTH_REDIRECT_FAILED 
+        # Confirm that there is a @params object from the redirect
+        assert !@params.nil?, OAUTH_REDIRECT_FAILED
 
         assert @params['error'].nil?, "Error returned from authorization server:  code #{@params['error']}, description: #{@params['error_description']}"
         assert @params['state'] == @instance.state, "OAuth server state querystring parameter (#{@params['state']}) did not match state from app #{@instance.state}"
@@ -150,9 +149,8 @@ module Inferno
         token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params.to_json, headers)
         assert_response_bad_or_unauthorized token_response
 
-        # Confirm that there is a @params object from the redirect 
-        assert !@params.nil?, OAUTH_REDIRECT_FAILED 
-
+        # Confirm that there is a @params object from the redirect
+        assert !@params.nil?, OAUTH_REDIRECT_FAILED
 
         oauth2_params = {
           'grant_type' => 'authorization_code',
@@ -174,8 +172,8 @@ module Inferno
           )
         end
 
-        # Confirm that there is a @params object from the redirect 
-        assert !@params.nil?, OAUTH_REDIRECT_FAILED 
+        # Confirm that there is a @params object from the redirect
+        assert !@params.nil?, OAUTH_REDIRECT_FAILED
 
         oauth2_params = {
           'grant_type' => 'authorization_code',
@@ -204,8 +202,8 @@ module Inferno
           )
         end
 
-        # Confirm that there is valid token 
-        assert !@token_response.nil?, NO_TOKEN 
+        # Confirm that there is valid token
+        assert !@token_response.nil?, NO_TOKEN
 
         @token_response_headers = @token_response.headers
         assert_valid_json(@token_response.body)
@@ -264,8 +262,8 @@ module Inferno
           )
         end
 
-        # Confirm that there is valid token 
-        assert !@token_response.nil?, NO_TOKEN 
+        # Confirm that there is valid token
+        assert !@token_response.nil?, NO_TOKEN
 
         [:cache_control, :pragma].each do |key|
           assert @token_response_headers.key?(key), "Token response headers did not contain #{key} as is required in the SMART App Launch Guide."

--- a/lib/app/modules/smart/standalone_launch_sequence.rb
+++ b/lib/app/modules/smart/standalone_launch_sequence.rb
@@ -78,7 +78,7 @@ module Inferno
         oauth_authorize_endpoint = @instance.oauth_authorize_endpoint
 
         # Confirm that oauth2_auth_endpoint is valid before moving forward
-        assert_is_valid_uri oauth_authorize_endpoint, "OAuth2 Authorization Endpoint: \"#{oauth_authorize_endpoint}\" is not a valid URI"
+        assert_valid_http_uri oauth_authorize_endpoint, "OAuth2 Authorization Endpoint: \"#{oauth_authorize_endpoint}\" is not a valid URI"
 
         oauth2_auth_query = oauth_authorize_endpoint
 

--- a/lib/app/modules/smart/standalone_launch_sequence.rb
+++ b/lib/app/modules/smart/standalone_launch_sequence.rb
@@ -79,7 +79,7 @@ module Inferno
         oauth_authorize_endpoint = @instance.oauth_authorize_endpoint
 
         # Confirm that oauth2_auth_endpoint is valid before moving forward
-        assert_is_valid_uri oauth_authorize_endpoint
+        assert_is_valid_uri oauth_authorize_endpoint, "OAuth2 Authorization Endpoint: \"#{oauth_authorize_endpoint}\" is not a valid URI"
 
         oauth2_auth_query = oauth_authorize_endpoint
 

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -263,11 +263,8 @@ module Inferno
       end
     end
 
-    def assert_valid_http_uri(uri, message = nil)
-      error_message = message
-      if error_message.nil?
-        error_message = "\"#{uri}\" is not a valid URI"
-      end
+    def assert_valid_http_uri(uri, message = nil)      
+      error_message = message || "\"#{uri}\" is not a valid URI"
       assert (uri =~ /\A#{URI.regexp(['http', 'https'])}\z/), error_message
     end
   end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
+
 require_relative 'assertions.rb'
 require 'uri'
+
 module Inferno
   module Assertions
     def assert(test, message = 'assertion failed, no message', data = '')
@@ -261,13 +263,11 @@ module Inferno
       end
     end
 
-    def assert_is_valid_uri(uri, message = nil)
-          
-          if message == nil
-            message = "\"#{uri}\" is not a valid URI"
-          end
-          assert uri =~ URI::regexp, message
+    def assert_is_valid_uri(uri, message = nil)          
+      if message.nil?
+        message = "\"#{uri}\" is not a valid URI"
+      end
+      assert uri =~ URI::DEFAULT_PARSER.make_regexp, message
     end
-
   end
 end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -263,7 +263,7 @@ module Inferno
       end
     end
 
-    def assert_valid_http_uri(uri, message = nil)      
+    def assert_valid_http_uri(uri, message = nil)
       error_message = message || "\"#{uri}\" is not a valid URI"
       assert (uri =~ /\A#{URI.regexp(['http', 'https'])}\z/), error_message
     end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -264,10 +264,11 @@ module Inferno
     end
 
     def assert_valid_http_uri(uri, message = nil)
-      if message.nil?
-        message = "\"#{uri}\" is not a valid URI"
+      error_message = message;
+      if error_message.nil?
+        error_message = "\"#{uri}\" is not a valid URI"
       end
-      assert (uri =~ /\A#{URI.regexp(['http', 'https'])}\z/), message
+      assert (uri =~ /\A#{URI.regexp(['http', 'https'])}\z/), error_message
     end
   end
 end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -264,7 +264,7 @@ module Inferno
     end
 
     def assert_valid_http_uri(uri, message = nil)
-      error_message = message;
+      error_message = message
       if error_message.nil?
         error_message = "\"#{uri}\" is not a valid URI"
       end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -261,8 +261,12 @@ module Inferno
       end
     end
 
-    def assert_is_valid_uri(uri)
-          assert uri =~ URI::regexp, "\"#{uri}\" is not a valid URI"
+    def assert_is_valid_uri(uri, message = nil)
+          
+          if message == nil
+            message = "\"#{uri}\" is not a valid URI"
+          end
+          assert uri =~ URI::regexp, message
     end
 
   end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-
 require_relative 'assertions.rb'
+require 'uri'
 module Inferno
   module Assertions
     def assert(test, message = 'assertion failed, no message', data = '')
@@ -260,5 +260,10 @@ module Inferno
           )
       end
     end
+
+    def assert_is_valid_uri(uri)
+          assert uri =~ URI::regexp, "\"#{uri}\" is not a valid URI"
+    end
+
   end
 end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -263,11 +263,11 @@ module Inferno
       end
     end
 
-    def assert_is_valid_uri(uri, message = nil)
+    def assert_valid_http_uri(uri, message = nil)
       if message.nil?
         message = "\"#{uri}\" is not a valid URI"
       end
-      assert uri =~ URI::DEFAULT_PARSER.make_regexp, message
+      assert (uri =~ /\A#{URI.regexp(['http', 'https'])}\z/), message
     end
   end
 end

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -263,7 +263,7 @@ module Inferno
       end
     end
 
-    def assert_is_valid_uri(uri, message = nil)          
+    def assert_is_valid_uri(uri, message = nil)
       if message.nil?
         message = "\"#{uri}\" is not a valid URI"
       end


### PR DESCRIPTION
Fixed issue where on redirect, if the returned oauth authorization uri is empty it will redirect to itself (also handle cases of invalid oauth authorization uri in general)

Added new assert_valid_http_uri 

Updated standalone_launch_sequence 
   02 to assert that the oauth authorization endpoint is valid before attempting to redirect 
   updated the other propagating tests to not crash when 02 fails to return a valid params and a valid tokens

Updated smart_discovery_sequence.rb
   replaced uri checkes with the new assert_valid_http_uri 

