### PR TITLE
FI-265 update background

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -125,7 +125,8 @@ module Inferno
                          instance: instance,
                          test_set: test_set,
                          sequence_results: instance.latest_results_by_case,
-                         tests_running: true)
+                         tests_running: true,
+                         test_group: test_group.id)
 
               out << js_hide_wait_modal
               out << js_show_test_modal
@@ -442,7 +443,8 @@ module Inferno
             out << erb(instance.module.view_by_test_set(params[:test_set]), {}, instance: instance,
                                                                                 test_set: test_set,
                                                                                 sequence_results: instance.latest_results_by_case,
-                                                                                tests_running: true)
+                                                                                tests_running: true,
+                                                                                test_group: test_group.id)
 
             next_test_case = submitted_test_cases.shift
             finished = next_test_case.nil?

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -80,9 +80,10 @@
     <% end %>
     <div class="group-nav">
       <ul class="nav nav-pills nav-fill">
+      <% test_group = "" if defined?(test_group).nil? %>
       <% instance.group_results(test_set.id).each_with_index do |group_with_result, index| %>
         <li class="nav-item group-result-<%= group_with_result[:result].to_s %>">
-          <a class="nav-link<%= if index == 0 then ' active' end %>" id="group-link-<%=group_with_result[:group].id%>" href="#group-<%=group_with_result[:group].id%>" data-toggle="tab">
+          <a class="nav-link<%= if (index == 0 && test_group.blank? ) || (test_group == group_with_result[:group].id) then ' active' end %>" id="group-link-<%=group_with_result[:group].id%>" href="#group-<%=group_with_result[:group].id%>" data-toggle="tab">
             <% case group_with_result[:result].to_s
               when 'pass' %>
               <div class="group-nav-score group-nav-score-pass" data-toggle="tooltip" title="Test Passed">
@@ -108,7 +109,7 @@
         <% instance.group_results(test_set.id).each_with_index do |group_with_result, index| %>
           <% group = group_with_result[:group] %>
           <% group_result = group_with_result[:result] %>
-          <div class="sequence-group sequence-action-boundary tab-pane<%= if index == 0 then ' active' end %>" data-group="<%= group.name %>" id="group-<%=group.id%>">
+          <div class="sequence-group sequence-action-boundary tab-pane<%= if (index == 0 && test_group.blank? ) || (test_group == group_with_result[:group].id) then ' active' end %>" data-group="<%= group.name %>" id="group-<%=group.id%>">
             <div class="sequence-header">
               <div class='align-items-center'>
                 <div class='group-overview-box'>


### PR DESCRIPTION
In guided mode, updated the background while tests are running to the currently running test, instead of always defaulting to Discovery & Registration.

<img width="958" alt="Screen Shot 2019-07-16 at 9 39 26 AM" src="https://user-images.githubusercontent.com/47094547/61299201-a4f1c680-a7ad-11e9-9d9a-c482429bb903.png">
